### PR TITLE
chore: bump deploy actions off Node 20, fix stale branch docs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,13 +19,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -33,7 +33,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}
           tags: |
@@ -41,7 +41,7 @@ jobs:
             type=sha
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,7 +148,7 @@ core/
 └── .env.example                      # Template for setup
 ```
 
-**Branches:** `main` (protected) | `dev` (default) | `feature/*`
+**Branches:** `main` (default; push to `main` deploys to production) | feature branches (`feat/*`, `fix/*`, `docs/*`, `chore/*`, `refactor/*`) → PR into `main`
 
 ---
 
@@ -301,7 +301,7 @@ GitHub push → Actions build → GHCR image → SSH → docker compose pull →
 1. Read this CLAUDE.md first, check branch (`git branch`), understand Rails conventions
 2. Follow Rails MVC patterns and conventions
 3. Survey docs before creating new `.md` files - propose organization first
-4. Work in `dev` branch, never commit directly to `main`
+4. Branch from `main` with a typed prefix (`feat/`, `fix/`, `docs/`, `chore/`, `refactor/`) and open a PR into `main`
 5. Update this CLAUDE.md if architecture changes
 6. Use Rails generators when appropriate
 7. Write tests for new features (RSpec or Minitest)


### PR DESCRIPTION
## Summary

Two maintenance fixes surfaced while merging PR #44.

**1. `deploy.yml` — Node 20 deprecation** (`a2f6880`)

GitHub forces Node 24 on JavaScript actions starting **2026-06-02**. Bumps the five flagged actions to their latest Node 24 majors:

| Action | Bump |
|--------|------|
| `actions/checkout` | v4 → v6 |
| `docker/setup-buildx-action` | v3 → v4 |
| `docker/login-action` | v3 → v4 |
| `docker/metadata-action` | v5 → v6 |
| `docker/build-push-action` | v5 → v7 |

`appleboy/ssh-action` is Docker-based — unaffected, left as-is.

**2. `CLAUDE.md` — stale branch workflow** (`946d28b`)

Corrected two references claiming `dev` is the default branch and `main` is "protected". Neither holds: `dev` has been unused since 2026-03-14 (zero unique commits), `main` is the default and unprotected, and work lands on `main` via typed feature branches.

## Test Plan

- [ ] CI green on PR
- [ ] Post-merge deploy succeeds on the new action versions — the real test, since `ci.yml` does not exercise `deploy.yml`
- [ ] `Verify deployment` step confirms `rectorspace.com/up` healthy