### PR TITLE
chore: bump remaining stale CI/deploy actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
         run: bin/rails db:test:prepare test:system
 
       - name: Keep screenshots from failed system tests
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: screenshots

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,7 +50,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Deploy to VPS
-        uses: appleboy/ssh-action@v1.0.3
+        uses: appleboy/ssh-action@v1.2.5
         with:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}


### PR DESCRIPTION
## Summary

Final two action bumps from the Dependabot backlog — supersedes #34 and #37.

| Action | Bump | File | Notes |
|--------|------|------|-------|
| `actions/upload-artifact` | v6 → v7 | `ci.yml` | failure-only screenshot upload step |
| `appleboy/ssh-action` | v1.0.3 → v1.2.5 | `deploy.yml` | within major v1, no breaking changes; runs the VPS deploy |

Once this merges, the gem bumps (#46) plus these clear the original 17-PR backlog.

## Test Plan

- [ ] CI green on PR
- [ ] Post-merge deploy succeeds — exercises the bumped `ssh-action` end-to-end via the `/up` health-check