### PR TITLE
fix: update OgImageGenerator to MiniMagick v5 API

### DIFF
--- a/app/services/og_image_generator.rb
+++ b/app/services/og_image_generator.rb
@@ -36,7 +36,7 @@ class OgImageGenerator
     FileUtils.mkdir_p(cache_file.dirname)
 
     # Build canvas with text layers
-    MiniMagick::Tool::Convert.new do |c|
+    MiniMagick.convert do |c|
       c.size "#{WIDTH}x#{HEIGHT}"
       c.xc BG_COLOR
 


### PR DESCRIPTION
## Summary
- `/og-image` has been returning **HTTP 500** in production since the gem dependency bump, silently breaking LinkedIn / Twitter / Slack social-share previews for rectorspace.com (homepage + every `/work/:slug`).
- Root cause: `mini_magick 5.3.1` removed the zero-arg initializer on `MiniMagick::Tool::Convert`. The constant still resolves (it's aliased to `MiniMagick::Tool`), but instantiating it without the command name raises `ArgumentError (wrong number of arguments (given 0, expected 1))` at `og_image_generator.rb:39`.
- One-line fix: switch to the idiomatic v5 entry point `MiniMagick.convert { |c| ... }`. `Image#composite` block API is unchanged in v5, so the profile composite step keeps working as-is.

## Test plan
- [x] Local regen confirmed: `bin/rails runner 'OgImageGenerator.cached_path'` produces a 51KB PNG with the NFT profile, "RECTOR" label, orange accent rule, "Building for Eternity" headline, dynamic stats line, and `rectorspace.com` footer
- [ ] Post-deploy: `curl -I https://rectorspace.com/og-image` returns `200` with `content-type: image/png`
- [ ] Re-fetch `https://rectorspace.com` and `https://rectorspace.com/work` link tiles on LinkedIn Experience → thumbnails resolve to the rendered OG card instead of the gray placeholder

## Production evidence
```
ArgumentError (wrong number of arguments (given 0, expected 1)):
  app/services/og_image_generator.rb:39:in `generate!'
  app/services/og_image_generator.rb:17:in `cached_path'
  app/controllers/og_images_controller.rb:5:in `show'
```