### PR TITLE
fix: serve OG image as static public/og-image.png for LinkedIn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ REVISION
 # Brainstorming specs and implementation plans — working artifacts auto-generated
 # per planning session. Curated documentation lives in docs/*.md instead.
 /docs/superpowers/
+/public/og-image.png

--- a/app/controllers/og_images_controller.rb
+++ b/app/controllers/og_images_controller.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-class OgImagesController < ApplicationController
-  def show
-    path = OgImageGenerator.cached_path
-    expires_in 1.hour, public: true
-    send_file path, type: "image/png", disposition: "inline"
-  end
-end

--- a/app/services/og_image_generator.rb
+++ b/app/services/og_image_generator.rb
@@ -21,7 +21,7 @@ class OgImageGenerator
   private
 
   def cache_file
-    Rails.root.join("tmp", "cache", "og", "og-image.png")
+    Rails.root.join("public", "og-image.png")
   end
 
   def valid_cache?

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,7 +18,7 @@
     <meta property="og:url" content="https://rectorspace.com<%= request.path %>">
     <meta property="og:title" content="<%= content_for(:title) ? "#{content_for(:title)} • RECTOR" : "RECTOR • Building for Eternity" %>">
     <meta property="og:description" content="<%= content_for(:meta_description) || "Full-stack builder. Hackathon hunter. #{achievements_summary}. Building for eternity." %>">
-    <meta property="og:image" content="<%= content_for(:og_image) || "https://rectorspace.com/og-image" %>">
+    <meta property="og:image" content="<%= content_for(:og_image) || "https://rectorspace.com/og-image.png" %>">
     <meta property="og:site_name" content="RECTOR">
 
     <%# Twitter Card meta tags %>
@@ -27,7 +27,7 @@
     <meta name="twitter:creator" content="@RZ1989sol">
     <meta name="twitter:title" content="<%= content_for(:title) ? "#{content_for(:title)} • RECTOR" : "RECTOR • Building for Eternity" %>">
     <meta name="twitter:description" content="<%= content_for(:meta_description) || "Full-stack builder. Hackathon hunter. #{achievements_summary}. Building for eternity." %>">
-    <meta name="twitter:image" content="<%= content_for(:og_image) || "https://rectorspace.com/og-image" %>">
+    <meta name="twitter:image" content="<%= content_for(:og_image) || "https://rectorspace.com/og-image.png" %>">
 
     <%= yield :head %>
 

--- a/config/initializers/og_image_warmup.rb
+++ b/config/initializers/og_image_warmup.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Regenerate public/og-image.png on app boot so social previews always
+# reflect the latest achievements.yml. Wrapped in rescue so a missing
+# ImageMagick install (e.g. on a fresh dev machine) doesn't crash boot.
+Rails.application.config.after_initialize do
+  OgImageGenerator.cached_path
+rescue => e
+  Rails.logger.warn "OG image warmup failed: #{e.class}: #{e.message}"
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,9 +14,6 @@ Rails.application.routes.draw do
   get "apply/arbital/modern", to: "apply#arbital_modern", as: :apply_arbital_modern
   get "apply/superteam",      to: "apply#superteam",      as: :apply_superteam
 
-  # Dynamic OG image (auto-updates from achievements.yml)
-  get "og-image", to: "og_images#show", as: :og_image
-
   # Health check
   get "up" => "rails/health#show", as: :rails_health_check
 


### PR DESCRIPTION
## Summary
- PR #54 fixed the MiniMagick v5 crash, so `/og-image` started returning a real PNG. But LinkedIn's Post Inspector still reported **`No image found`** for `https://rectorspace.com`.
- Two compounding causes verified against LinkedIn Post Inspector + raw curl:
  1. `send_file` returns `HEAD` with `content-length: 0` (Rails only writes the body length on `GET`). LinkedIn HEADs first and treats zero-length as "image missing."
  2. The URL had no file extension. LinkedIn's parser prefers URLs ending in a recognized image extension.
- Pivot: write the OG image directly to `public/og-image.png` and let Thruster serve it as a real static asset. Both blockers disappear:
  - Thruster sets a correct `Content-Length` for HEAD and GET (verified locally: `content-length: 51090` on both methods)
  - URL is now `/og-image.png`
- Regeneration on boot via a small `after_initialize` hook in `config/initializers/og_image_warmup.rb`. Cache check short-circuits when the existing file is newer than `achievements.yml`, so dev boot isn't slowed down.

## Test plan
- [x] Local `bin/rails runner 'OgImageGenerator.cached_path'` writes the 51KB PNG to `public/og-image.png` instead of `tmp/cache/og/`
- [x] Local `curl -I http://localhost:3334/og-image.png` returns `200`, `content-type: image/png`, `content-length: 51090`
- [x] Local `curl -X GET -I http://localhost:3334/og-image.png` returns identical headers
- [x] `bin/rails routes | grep og` returns nothing (dynamic route removed)
- [ ] Post-deploy: `curl -I https://rectorspace.com/og-image.png` matches local
- [ ] LinkedIn Post Inspector re-scrape of `https://rectorspace.com` shows the rendered OG card under "When this link is shared..."
- [ ] RECTOR LABS LinkedIn Experience link tiles refresh from placeholder thumbs to the brand card

## Files
- `app/services/og_image_generator.rb` — cache path → `public/og-image.png`
- `config/initializers/og_image_warmup.rb` — regenerate on boot (rescue-guarded)
- `app/views/layouts/application.html.erb` — `og:image` + `twitter:image` → `/og-image.png`
- `config/routes.rb` — remove dynamic `og-image` route
- `app/controllers/og_images_controller.rb` — deleted
- `.gitignore` — ignore generated `public/og-image.png`