### PR TITLE
feat: Journal section + first post (Understanding Vercel Usage)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ Single domain `rectorspace.com` with route-based sections:
 | Homepage | / | Identity hub & landing | ✅ Live |
 | Work | /work | Story-driven project showcase | ✅ Live |
 | Labs | /labs | Experiments & learning projects | 📋 Planned |
-| Journal | /journal | Blog & writings (Ghost CMS integration) | 📋 Planned |
+| Journal | /journal | Blog & writings (native file-based markdown) | ✅ Live |
 | Cheatsheet | /cheatsheet | Dev reference & notes | 📋 Planned |
 | Dakwa | /dakwa | Islamic da'wah content | 📋 Planned |
 | Quran | /quran | Quranic resources & tools | 📋 Planned |
@@ -98,7 +98,7 @@ Single domain `rectorspace.com` with route-based sections:
 - Rails monolith for unified codebase, shared authentication, single deployment
 - Route-based sections instead of separate apps/subdomains
 - Work (story-driven narratives) separate from Labs (experiments/learning)
-- Ghost CMS as external service, integrated via API for Journal section
+- Journal section uses native file-based markdown (no external CMS)
 
 ---
 
@@ -264,10 +264,9 @@ GitHub push → Actions build → GHCR image → SSH → docker compose pull →
 ## External Integrations
 
 **Journal Section:**
-- Ghost CMS hosted separately (journal subdomain or external)
-- Integrate via Ghost Content API
-- Fetch posts and display in `/journal` route
-- Consider caching strategy for performance
+- Native file-based blog (no external CMS) — content lives in git
+- Posts are markdown files in `content/journal/*.md` with YAML front matter
+- Rendered via the `Post` PORO + shared `markdown()` helper (Redcarpet); deploy = publish
 
 **Work Section:**
 - Story-driven project pages (narrative format, not traditional portfolio)
@@ -452,13 +451,54 @@ resources :works, only: [:index, :show]
 
 ---
 
+## Journal Section (File-Based Blog)
+
+**Implemented Features:**
+- Native file-based blog at `/journal` (no Ghost CMS — content lives in git, PR-reviewable)
+- Posts are markdown files with YAML front matter in `content/journal/*.md`
+- Rendered via the shared `markdown()` helper (Redcarpet); drafts excluded from the index and 404 on show
+- Warm cream theme with dedicated prose + table styling (`journal.css`)
+
+**Front Matter:**
+```yaml
+---
+title: Post Title
+slug: optional-slug        # defaults to the filename without .md
+date: 2026-05-30
+summary: One-line excerpt (listing + meta description)
+tags: [tag1, tag2]
+draft: false               # drafts excluded from index and 404 on show
+---
+```
+
+**Architecture:**
+```
+content/journal/*.md                    # source of truth (one file per post)
+app/models/post.rb                      # PORO: all/published/recent/find, reading_time
+app/controllers/journal_controller.rb   # index + show (drafts/unknown -> 404)
+app/views/journal/index.html.erb        # post listing
+app/views/journal/show.html.erb         # article (OG article meta)
+app/assets/stylesheets/journal.css      # prose + table styling
+app/helpers/markdown_helper.rb          # shared markdown() (also used by Work)
+```
+
+**Routes:**
+```ruby
+get "journal", to: "journal#index", as: :journal
+get "journal/:slug", to: "journal#show", as: :journal_post
+```
+
+**To add a post:** create `content/journal/<slug>.md` with front matter + markdown body, commit, deploy. The homepage "Latest article" and the `/journal` index update automatically.
+
+---
+
 ## Resources
 
-**Docs:** [Rails Guides](https://guides.rubyonrails.org) | [Tailwind CSS](https://tailwindcss.com/docs) | [Ghost API](https://ghost.org/docs/content-api/)
+**Docs:** [Rails Guides](https://guides.rubyonrails.org) | [Tailwind CSS](https://tailwindcss.com/docs) | [Redcarpet](https://github.com/vmg/redcarpet)
 
 **Links:** [@rz1989s](https://github.com/rz1989s) | [RECTOR-LABS](https://github.com/RECTOR-LABS) | [rectorspace.com](https://rectorspace.com)
 
-**Maintainer:** RECTOR | **Updated:** 2025-11-03 | **Version:** 3.1 (Work Section Live)
+**Maintainer:** RECTOR | **Updated:** 2026-05-30 | **Version:** 3.2 (Journal Section Live)
 
 ---
 

--- a/app/assets/stylesheets/journal.css
+++ b/app/assets/stylesheets/journal.css
@@ -1,1 +1,36 @@
-/* Journal styles — populated in the styling task. */
+/* Journal listing */
+.journal-list { list-style: none; padding: 0; margin: 0; }
+.journal-list-item { padding: 1.5rem 0; border-bottom: 1px solid rgba(59, 44, 34, 0.1); }
+.journal-list-link { text-decoration: none; }
+.journal-list-title { font-size: 1.4rem; font-weight: 700; color: #3B2C22; margin: 0 0 .35rem; transition: color .15s; }
+.journal-list-link:hover .journal-list-title { color: #41CFFF; }
+.journal-list-link:focus-visible { outline: 2px solid #41CFFF; outline-offset: 2px; border-radius: 2px; }
+.journal-list-meta { font-size: .85rem; color: rgba(59, 44, 34, .75); margin-bottom: .5rem; }
+.journal-list-summary { color: rgba(59, 44, 34, .8); line-height: 1.6; margin: 0 0 .5rem; }
+
+/* Tags */
+.journal-tags { display: flex; flex-wrap: wrap; gap: .4rem; }
+.journal-tag { font-size: .72rem; padding: .15rem .5rem; border-radius: .35rem; background: rgba(59, 44, 34, .06); color: rgba(59, 44, 34, .75); }
+
+/* Article prose */
+.journal-content { font-size: 1.0625rem; line-height: 1.8; }
+.journal-content h1 { font-size: 2rem; font-weight: 700; margin: 2.5rem 0 1rem; color: #3B2C22; }
+.journal-content h2 { font-size: 1.6rem; font-weight: 700; margin: 2.25rem 0 .9rem; color: #3B2C22; }
+.journal-content h3 { font-size: 1.25rem; font-weight: 600; margin: 1.75rem 0 .6rem; color: #3B2C22; }
+.journal-content p { margin: 0 0 1.25rem; }
+.journal-content a { color: #41CFFF; text-decoration: underline; text-underline-offset: 2px; }
+.journal-content a:hover { color: #E58C2E; }
+.journal-content ul, .journal-content ol { margin: 0 0 1.25rem 1.25rem; }
+.journal-content li { margin: .35rem 0; }
+.journal-content blockquote { border-left: 3px solid #F9C846; padding-left: 1rem; margin: 1.25rem 0; color: rgba(59, 44, 34, .8); }
+.journal-content code { background: rgba(59, 44, 34, .07); padding: .1rem .35rem; border-radius: .25rem; font-size: .9em; }
+.journal-content pre { background: #3B2C22; color: #FFF7E1; padding: 1rem; border-radius: .5rem; overflow-x: auto; margin: 0 0 1.25rem; }
+.journal-content pre code { background: transparent; padding: 0; color: inherit; }
+.journal-content hr { border: 0; border-top: 1px solid rgba(59, 44, 34, .15); margin: 2rem 0; }
+.journal-content img { max-width: 100%; height: auto; border-radius: .35rem; }
+
+/* Tables — this post is table-heavy */
+.journal-content table { width: 100%; border-collapse: collapse; margin: 0 0 1.5rem; font-size: .95rem; display: block; overflow-x: auto; }
+.journal-content thead th { background: rgba(249, 200, 70, .25); text-align: left; font-weight: 600; }
+.journal-content th, .journal-content td { border: 1px solid rgba(59, 44, 34, .15); padding: .55rem .7rem; vertical-align: top; }
+.journal-content tbody tr:nth-child(even) { background: rgba(59, 44, 34, .03); }

--- a/app/assets/stylesheets/journal.css
+++ b/app/assets/stylesheets/journal.css
@@ -29,8 +29,10 @@
 .journal-content hr { border: 0; border-top: 1px solid rgba(59, 44, 34, .15); margin: 2rem 0; }
 .journal-content img { max-width: 100%; height: auto; border-radius: .35rem; }
 
-/* Tables — this post is table-heavy */
-.journal-content table { width: 100%; border-collapse: collapse; margin: 0 0 1.5rem; font-size: .95rem; display: block; overflow-x: auto; }
+/* Tables — this post is table-heavy. Break wide reference tables out beyond the
+   prose column (which stays at a readable measure), centered, capped to the viewport
+   so they fit on desktop without horizontal scroll and never exceed the screen. */
+.journal-content table { width: min(70rem, 92vw); border-collapse: collapse; margin: 0 0 1.5rem; font-size: .95rem; position: relative; left: 50%; transform: translateX(-50%); }
 .journal-content thead th { background: rgba(249, 200, 70, .25); text-align: left; font-weight: 600; }
 .journal-content th, .journal-content td { border: 1px solid rgba(59, 44, 34, .15); padding: .55rem .7rem; vertical-align: top; }
 .journal-content tbody tr:nth-child(even) { background: rgba(59, 44, 34, .03); }

--- a/app/assets/stylesheets/journal.css
+++ b/app/assets/stylesheets/journal.css
@@ -1,0 +1,1 @@
+/* Journal styles — populated in the styling task. */

--- a/app/controllers/journal_controller.rb
+++ b/app/controllers/journal_controller.rb
@@ -5,7 +5,7 @@ class JournalController < ApplicationController
 
   def show
     @post = Post.find(params[:slug])
-    return render_not_found if @post.nil? || @post.draft?
+    render_not_found if @post.nil? || @post.draft?
   end
 
   private

--- a/app/controllers/journal_controller.rb
+++ b/app/controllers/journal_controller.rb
@@ -1,0 +1,16 @@
+class JournalController < ApplicationController
+  def index
+    @posts = Post.recent
+  end
+
+  def show
+    @post = Post.find(params[:slug])
+    return render_not_found if @post.nil? || @post.draft?
+  end
+
+  private
+
+  def render_not_found
+    render file: Rails.public_path.join("404.html"), status: :not_found, layout: false
+  end
+end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -31,6 +31,9 @@ class PagesController < ApplicationController
     # Currently building (most recently pushed repo) - kept for activity bar
     @currently_building = GithubRepo.currently_building
 
+    # Latest journal post for homepage Writing section
+    @latest_post = Post.recent.first
+
     # If cache is empty, trigger sync job and show placeholder
     if @latest_projects.empty?
       SyncGithubReposJob.perform_later

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "redcarpet"
+
+module MarkdownHelper
+  def markdown(text)
+    return "" if text.blank?
+
+    renderer = Redcarpet::Render::HTML.new(
+      hard_wrap: false,
+      link_attributes: { target: "_blank", rel: "noopener" }
+    )
+
+    markdown = Redcarpet::Markdown.new(renderer,
+      autolink: true,
+      tables: true,
+      fenced_code_blocks: true,
+      strikethrough: true,
+      superscript: true,
+      space_after_headers: true
+    )
+
+    markdown.render(text).html_safe
+  end
+end

--- a/app/helpers/works_helper.rb
+++ b/app/helpers/works_helper.rb
@@ -1,23 +1,3 @@
 module WorksHelper
-  def markdown(text)
-    return "" if text.blank?
-
-    require "redcarpet"
-
-    renderer = Redcarpet::Render::HTML.new(
-      hard_wrap: false,  # Don't convert line breaks to <br> - use proper paragraphs
-      link_attributes: { target: "_blank", rel: "noopener" }
-    )
-
-    markdown = Redcarpet::Markdown.new(renderer,
-      autolink: true,
-      tables: true,
-      fenced_code_blocks: true,
-      strikethrough: true,
-      superscript: true,
-      space_after_headers: true  # Add space after headers
-    )
-
-    markdown.render(text).html_safe
-  end
+  # markdown() now lives in MarkdownHelper (included in all views by Rails).
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+# Post PORO — loads journal posts from markdown files with YAML front matter.
+# Single source of truth: content/journal/*.md  (mirrors the Achievement YAML pattern).
+class Post
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  FRONT_MATTER = /\A---\s*\r?\n(?<yaml>.*?)\r?\n---\s*\r?\n(?<body>.*)\z/m
+
+  attribute :slug, :string
+  attribute :title, :string
+  attribute :summary, :string
+  attribute :body, :string
+  attribute :published_on, :date
+  attribute :draft, :boolean, default: false
+  attribute :og_image, :string
+  attribute :tags, default: -> { [] }
+
+  class << self
+    attr_writer :content_dir
+
+    def content_dir
+      @content_dir || Rails.root.join("content", "journal")
+    end
+
+    def all
+      if Rails.env.production?
+        @all ||= load_all
+      else
+        load_all
+      end
+    end
+
+    def published
+      all.reject(&:draft?)
+    end
+
+    def recent
+      published.sort_by { |p| p.published_on || Date.new(0) }.reverse
+    end
+
+    def find(slug)
+      all.find { |p| p.slug == slug }
+    end
+
+    def reload!
+      @all = nil
+    end
+
+    private
+
+    def load_all
+      Dir.glob(content_dir.join("*.md")).map { |path| from_file(path) }
+    end
+
+    def from_file(path)
+      front, body = parse(File.read(path))
+      new(
+        slug: front["slug"].presence || File.basename(path, ".md"),
+        title: front["title"],
+        summary: front["summary"],
+        body: body,
+        published_on: front["date"],
+        draft: front.fetch("draft", false),
+        og_image: front["og_image"],
+        tags: Array(front["tags"])
+      )
+    end
+
+    def parse(raw)
+      if (m = raw.match(FRONT_MATTER))
+        [ YAML.safe_load(m[:yaml], permitted_classes: [ Date, Time ]) || {}, m[:body] ]
+      else
+        [ {}, raw ]
+      end
+    end
+  end
+
+  def to_param
+    slug
+  end
+
+  def draft?
+    draft
+  end
+
+  def reading_time
+    words = body.to_s.split.size
+    [ (words / 200.0).ceil, 1 ].max
+  end
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -86,7 +86,10 @@ class Post
   end
 
   def reading_time
-    words = body.to_s.split.size
+    # Count prose only — exclude markdown table rows (GFM rows start with "|"),
+    # which are dense reference content, not reading-paced prose.
+    prose = body.to_s.lines.reject { |line| line.lstrip.start_with?("|") }.join(" ")
+    words = prose.split.size
     [ (words / 200.0).ceil, 1 ].max
   end
 end

--- a/app/views/journal/index.html.erb
+++ b/app/views/journal/index.html.erb
@@ -1,0 +1,39 @@
+<% content_for :title, "Journal" %>
+<% content_for :meta_description, "Notes and writings on what I'm building and learning." %>
+
+<%= stylesheet_link_tag "journal", "data-turbo-track": "reload" %>
+
+<div class="max-w-3xl mx-auto px-4 sm:px-6 py-8 sm:py-12">
+  <div class="mb-6 sm:mb-8">
+    <%= link_to "← Home", root_path, class: "text-[#41CFFF] hover:text-[#E58C2E] transition-colors" %>
+  </div>
+
+  <header class="mb-8 sm:mb-10 pb-6 border-b-2 border-[#3B2C22]/10">
+    <h1 class="text-3xl sm:text-4xl font-bold text-[#3B2C22] mb-2">Journal</h1>
+    <p class="text-[#3B2C22]/60">Notes on what I'm building and learning.</p>
+  </header>
+
+  <% if @posts.any? %>
+    <ul class="journal-list">
+      <% @posts.each do |post| %>
+        <li class="journal-list-item">
+          <%= link_to journal_post_path(post), class: "journal-list-link" do %>
+            <h2 class="journal-list-title"><%= post.title %></h2>
+          <% end %>
+          <div class="journal-list-meta">
+            <% if post.published_on %><time datetime="<%= post.published_on.iso8601 %>"><%= post.published_on.strftime("%B %-d, %Y") %></time> · <% end %>
+            <span><%= post.reading_time %> min read</span>
+          </div>
+          <p class="journal-list-summary"><%= post.summary %></p>
+          <% if post.tags.present? %>
+            <div class="journal-tags">
+              <% post.tags.each do |tag| %><span class="journal-tag"><%= tag %></span><% end %>
+            </div>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  <% else %>
+    <p class="text-[#3B2C22]/50">No posts yet. Check back soon.</p>
+  <% end %>
+</div>

--- a/app/views/journal/show.html.erb
+++ b/app/views/journal/show.html.erb
@@ -1,0 +1,31 @@
+<% content_for :title, @post.title %>
+<% content_for :meta_description, @post.summary %>
+<% content_for :og_type, "article" %>
+<% content_for :og_image, @post.og_image if @post.og_image.present? %>
+
+<%= stylesheet_link_tag "journal", "data-turbo-track": "reload" %>
+
+<div class="max-w-3xl mx-auto px-4 sm:px-6 py-8 sm:py-12">
+  <div class="mb-6 sm:mb-8">
+    <%= link_to "← Journal", journal_path, class: "text-[#41CFFF] hover:text-[#E58C2E] transition-colors" %>
+  </div>
+
+  <article class="max-w-none">
+    <header class="mb-6 sm:mb-8 pb-6 border-b-2 border-[#3B2C22]/10">
+      <h1 class="text-2xl sm:text-4xl font-bold mb-3 text-[#3B2C22]"><%= @post.title %></h1>
+      <div class="flex flex-wrap items-center gap-3 text-sm text-[#3B2C22]/60">
+        <% if @post.published_on %><time datetime="<%= @post.published_on.iso8601 %>"><%= @post.published_on.strftime("%B %-d, %Y") %></time> · <% end %>
+        <span><%= @post.reading_time %> min read</span>
+      </div>
+      <% if @post.tags.present? %>
+        <div class="journal-tags mt-3">
+          <% @post.tags.each do |tag| %><span class="journal-tag"><%= tag %></span><% end %>
+        </div>
+      <% end %>
+    </header>
+
+    <div class="journal-content text-[#3B2C22]">
+      <%= markdown(@post.body) %>
+    </div>
+  </article>
+</div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -31,7 +31,7 @@
     Explore:
     <%= link_to "work", works_path %> •
     <%= link_to "labs", "#" %> •
-    <%= link_to "journal", "#" %> •
+    <%= link_to "journal", journal_path %> •
     <%= link_to "cheatsheet", "#" %>
   </div>
 
@@ -182,12 +182,13 @@
   <!-- Writing Section -->
   <section>
     <h2>Writing</h2>
-    <p class="mt-4 mb-2">
-      <strong>Latest article:</strong>
-      <%= link_to "Coming Soon", "#" %>
-    </p>
+    <% if @latest_post %>
+      <p class="mt-4 mb-2">
+        <strong>Latest article:</strong>
+        <%= link_to @latest_post.title, journal_post_path(@latest_post) %>
+      </p>
+    <% end %>
     <p>
-      Journal section powered by Ghost CMS, integrated via API.
       Articles about code, faith, and building for eternity.
     </p>
   </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,10 @@ Rails.application.routes.draw do
   # Work section - story-driven project showcase
   resources :works, path: "work", only: [ :index, :show ]
 
+  # Journal section - file-based blog
+  get "journal", to: "journal#index", as: :journal
+  get "journal/:slug", to: "journal#show", as: :journal_post
+
   # Apply section - targeted CVs for specific companies
   get "apply/arbital",        to: "apply#arbital",        as: :apply_arbital
   get "apply/arbital/retro",  to: "apply#arbital_retro",  as: :apply_arbital_retro

--- a/content/journal/understanding-vercel-usage.md
+++ b/content/journal/understanding-vercel-usage.md
@@ -1,0 +1,168 @@
+---
+title: Understanding Vercel Usage
+slug: understanding-vercel-usage
+date: 2026-05-30
+summary: A line-by-line tour of every meter on the Vercel usage dashboard — what each one measures, how it's billed, and how to keep it low.
+tags: [vercel, infrastructure, devops, cost]
+draft: false
+---
+
+The first time I opened the Vercel usage dashboard, I genuinely did not know what I was looking at. I had expected a single number — bandwidth, maybe, or "compute hours." Instead I found something closer to fifty separate meters spread across eleven categories: Fast Data Transfer, Fast Origin Transfer, Edge Requests, ISR Reads, ISR Writes, Image Transformations, Function Invocations, Active CPU, Provisioned Memory, Build CPU Minutes, Blob operations, Queue sends, Trace Spans, and a long tail of things I had never heard of. It looked less like a bill and more like a parts catalog for a machine I had been driving without ever opening the hood.
+
+I'm on the free Hobby tier, so none of this costs me anything. But I think usage literacy matters even when you're paying zero, and here's why. The same meters that read "free" on Hobby are the exact meters that read "dollars" on Pro — the only thing that changes is the column to the right. If I understand what drives each number now, I'll already know where the money is when a project graduates to a paid plan. And the plans behave differently in a way worth internalizing up front. On Pro, when you hit 100% of an allowance, your deployments are not automatically stopped — that resource simply switches to on-demand (pay-as-you-go) billing so your site stays live through a traffic spike. On Hobby there is no overage to buy: exceed an included allowance and that feature pauses until the allowance resets (in most cases you wait until 30 days have passed). Hobby is also restricted to genuinely non-commercial personal use under Vercel's [Fair Use Guidelines](https://vercel.com/docs/limits/fair-use-guidelines) — anything commercial is supposed to be on Pro or above.
+
+So this post is me reading my own dashboard, top to bottom, and writing down what every meter actually means. All the numbers and units below come straight from Vercel's official docs.
+
+## The mental model: five buckets and a billing rule
+
+Once I stopped reading the meters alphabetically and started grouping them by *what they're for*, the whole thing collapsed into five buckets:
+
+1. **Get bytes to users** — the CDN layer: data transfer and request counts.
+2. **Render and cache** — turning data into pages and remembering the result: ISR, the Data Cache, image optimization.
+3. **Run your code** — functions, Fluid Compute, edge runtimes, middleware.
+4. **Ship it** — builds and the Turborepo remote cache.
+5. **Data and platform add-ons** — Blob storage, Queues, Cron, observability, flags, BotID, Sandbox.
+
+Underneath all of them sits one billing rule, and it's the most important sentence in this whole post. Vercel's "Managed Infrastructure" is billed by *actual resource consumption* — data transferred, requests made, compute duration — not a flat fee. Every product breaks down into resources, and each resource has an **included allowance** plus an **on-demand** rate beyond it. On Pro, the order of charging is: each resource first consumes its own included allocation; then usage beyond that draws against a $20/month credit that applies across all managed-infrastructure resources; and only after that credit is exhausted does it bill at the true on-demand per-unit rate. The credit and allocations reset monthly and don't roll over. On Hobby there's no credit and no overage — the included allowance is the whole story, and crossing it pauses the feature. Vercel's [pricing overview](https://vercel.com/docs/pricing) is the canonical reference for this structure.
+
+With that frame, here's the line-by-line tour.
+
+## Get bytes to users (the CDN)
+
+This is the networking bucket: the cost of moving bytes between Vercel's edge and either the visitor or your own origin compute. Every page view touches at least two of these meters at once — a transfer and a request. Most of them are *regionally priced*, meaning the per-unit rate varies by the region where requests originate.
+
+| Metric | What it measures | Unit / how it's billed | What drives it up | How to lower it |
+|---|---|---|---|---|
+| Fast Data Transfer | Data sent between the CDN and the visitor's device | GB, regional; counts the full body, all headers, the full URL, and any compression | Big page weights, unoptimized images, large JS/CSS bundles, high traffic, large uploads | Image optimization, trim bundles, smaller assets; use the Regions filter to find heavy traffic |
+| Fast Origin Transfer | Data sent between the CDN and Functions / Middleware / Blob / Data Cache | GB, regional; billed both directions of compute I/O | Large/extraneous function responses, big uploads, Middleware that also hits a function (can count twice), ISR generation | Return only needed fields, add Cache-Control, support ETag/If-Modified-Since, scope Middleware with a matcher |
+| Edge Requests | Count of requests the CDN processes (static assets *and* functions) | Raw count, regional; each request = 1 | High visit volume, many assets per page, re-mounting that refetches, polling / refetch-on-focus | Cache, cut re-mounting (watch repeated 304s), reduce polling, consolidate assets |
+| Edge Request CPU Duration | CPU the CDN burns on routing per request | CPU time; ≤10 ms per request is free, then metered in 10 ms increments, regional | Many routes, many redirects, complex routing regexes | Fewer routes/redirects, simpler regexes; diff the deployment where it jumped |
+| Microfrontends Routing | Requests routed across your microfrontends | Count of routed requests; each = 1 | Traffic across a microfrontends setup, cross-microfrontend navigations, more projects | Optimize navigations, consolidate microfrontend projects |
+
+On included allowances: Hobby gives you **100 GB** of Fast Data Transfer per month and **1,000,000 Edge Requests**; Pro raises those to **1 TB** and **10,000,000** respectively. Fast Origin Transfer and Edge Request CPU Duration have no published flat included tier in the pricing tables — the only "free" provision documented for CPU Duration is that 10 ms-per-request threshold. Microfrontends Routing includes **50,000** requests/month on Hobby (Pro has no fixed tier). The full breakdown lives in Vercel's [CDN usage docs](https://vercel.com/docs/manage-cdn-usage).
+
+## Render and cache
+
+This bucket is about *not doing work twice*. It covers Incremental Static Regeneration (ISR), the Data Cache, and image optimization. The recurring theme: a free ephemeral CDN cache sits in front of a billed durable cache, and you pay when requests fall through to the durable layer.
+
+ISR and the Data Cache share an elegant unit: the **8 KB Read Unit** and **8 KB Write Unit**. A read happens on a CDN miss that falls back to the durable cache in your function region; a write happens when content is first generated or when revalidation produces *different* content. The killer detail I didn't expect: if revalidation runs but the regenerated content is identical to what was cached, **no write units are incurred at all** — and that's true for both time-based and on-demand revalidation. Writes cost exactly 10x reads per unit.
+
+| Metric | What it measures | Unit / how it's billed | What drives it up | How to lower it |
+|---|---|---|---|---|
+| ISR Reads | Data read from the durable ISR cache on CDN misses | 8 KB Read Units, regional ($0.40–$0.64 per 1M) | CDN cache misses, short revalidation intervals, large payloads, frequent deploys (each gets a fresh cache) | Longer revalidation, selective pre-rendering, smaller payloads, cost-optimal region |
+| ISR Writes | New data durably written to the ISR cache | 8 KB Write Units, regional ($4.00–$6.40 per 1M) | Short revalidation, aggressive on-demand revalidation, non-deterministic output (`new Date()`, `Math.random()`) | Longer intervals, event-driven revalidation, remove non-determinism |
+| Data Cache Reads | Cached `fetch`/`unstable_cache` results read back (Next.js 14 and below) | 8 KB Read Units, regional ($0.40–$0.64 per 1M) | High cache-hit traffic, large cached payloads, running in multiple regions (one cache each) | Cache only needed fields, consolidate regions |
+| Data Cache Writes | New/revalidated cache entries stored | 8 KB Write Units, regional ($4.00–$6.40 per 1M) | Frequent changed-content revalidation, large items, non-deterministic output | Longer intervals, on-demand revalidation, deterministic output |
+| Data Cache Bandwidth | Data movement for the cache (not a separate billed line) | Surfaces under Fast Data / Fast Origin Transfer, not its own meter | Larger payloads, higher traffic, cross-region movement | Optimize the underlying transfer resources |
+| Data Cache Revalidations | Count of revalidation events | A count in Observability, not a priced unit | Short intervals, frequent on-demand calls, broad cache tags | Lengthen intervals, scope tags tightly, deterministic output |
+| Image Transformations | Optimizing operations (per cache miss/stale) | 1 transformation each, regional ($0.05–$0.0812 per 1K) | Many width/quality/format variants, multiple formats, short TTLs | Long TTL, single format, fewer sizes/qualities |
+| Image Cache Reads | Optimized images fetched from the shared global cache | 8 KB Read Units ($0.40–$0.64 per 1M) | Cross-region traffic, larger optimized files | Lower quality, efficient formats, keep in-region caches warm |
+| Image Cache Writes | Optimized images written to the global cache (per miss/stale) | 8 KB Write Units ($4.00–$6.40 per 1M) | Many first-time variants, short TTLs, large files | Long TTL, fewer variants, lower quality |
+| Source Images (Legacy) | Unique source images requested (old model) | $5.00 per 1,000 source images | Number of distinct source `src` values requested | Reuse sources; mark tiny/SVG/GIF as unoptimized |
+
+Two things worth flagging. The ISR and Data Cache reads/writes don't list a published included allowance in the pricing tables — they appear only as on-demand rows, so I don't assume a free tier there. Image optimization *does*: Hobby includes **5,000 transformations**, **300,000 image cache reads**, and **100,000 image cache writes** per month. The "Source Images" line is the *legacy* model that the transformation-based model replaced in early 2025; it bills per unique source rather than per variant. Vercel's [ISR pricing page](https://vercel.com/docs/incremental-static-regeneration/limits-and-pricing) and [image optimization pricing](https://vercel.com/docs/image-optimization/limits-and-pricing) are the references here.
+
+## Run your code
+
+This is the bucket I find most interesting, because the billing model under it genuinely changed. The headliner is **Fluid Compute**.
+
+Here's the short version. Traditional serverless billed a single wall-clock number: memory multiplied by elapsed time, *including* every millisecond your function sat idle waiting on a database query or an AI model call. Fluid Compute splits that into separate dimensions and — this is the part that matters — **only bills Active CPU while your code is actually running**. If a function spends 100 ms processing data and 400 ms waiting on a DB query, you're billed for the 100 ms of CPU, not the 400 ms of waiting. Memory still bills for the instance's whole lifetime (it stays reserved during I/O), but between requests, once the instance pauses, nothing is billed. Vercel's own one-liner is "you pay for memory whenever work is in progress, never for idle CPU, and nothing at all between requests." On top of that, multiple invocations can share one instance (optimized concurrency), so fewer instances run for the same traffic. It's been the default for new projects since April 2025.
+
+| Metric | What it measures | Unit / how it's billed | What drives it up | How to lower it |
+|---|---|---|---|---|
+| Function Invocations | Each request that reaches the function | Count (per million); success + error both count, cache hits excluded | Traffic, chatty clients, uncached routes, polling, ISR revalidations | Cache responses (cache hits don't count), batch calls, static/ISR |
+| Function Duration (GB-Hours) | Legacy/non-Fluid: memory × wall-clock time | GB-Hours, includes I/O wait | Long execution, high memory, high volume | Enable Fluid Compute; lower memory, cap `maxDuration`, cache |
+| Function Throttles | Requests not served because the concurrency limit was hit | Count — **not** a billed metric (health signal) | Traffic spikes outrunning burst scaling, slow functions holding instances | Reduce duration, enable Fluid concurrency, spread across regions |
+| Fluid Provisioned Memory | Memory reserved for the instance lifetime (incl. I/O) | GB-Hours, regional | Higher configured memory, long instance lifetimes, background `waitUntil` | Right-size memory, optimized concurrency, shorten I/O waits |
+| Fluid Active CPU | CPU time while code is *actively* running (not I/O) | CPU time per CPU-hour, regional | CPU-bound work (image processing, crypto, parsing) | Offload heavy compute, cache results, optimize algorithms |
+| Edge Function Invocations | Times an Edge-runtime function runs (deprecated runtime) | Count; success + error, cache hits excluded | Raw traffic, low cache-hit ratio, polling | Cache; migrate to Node.js on Fluid Compute |
+| Edge Execution Units | Edge CPU bucketed into 50 ms blocks | 1 unit = up to 50 ms CPU (net, excludes I/O wait) | CPU-bound work per invocation | Keep per-request CPU under 50 ms, cache, migrate |
+| Edge Function CPU Time | Net CPU the Edge function spends computing | CPU ms, then bucketed into 50 ms units | Computation (parse, crypto, render); not I/O waits | Reduce compute, cache, push I/O to async awaits |
+| Edge Middleware Invocations | Times Routing Middleware runs (before the cache) | Count, priced via Fluid Compute model | Broad matchers, site-wide auth/redirect/personalization | Narrow the matcher, return early, exclude static assets |
+| Edge Middleware CPU Time | Net CPU the middleware spends per invocation | CPU ms; Fair Use caps it at 50 ms average | Heavy routing/regex, JWT/crypto, big cookie parsing | Keep middleware lightweight, push heavy work downstream |
+
+On allowances: **1,000,000 Function Invocations** are included on both Hobby and Pro, with Pro on-demand at $0.60 per million beyond that. Active CPU includes **4 CPU-hours** on Hobby (Pro 16), and Provisioned Memory includes **360 GB-hours** on Hobby (Pro 1440). Worth noting that Edge Functions are now officially deprecated — the docs literally title the page "Do not use Edge Functions" — and Vercel directs new work to the Node.js runtime on Fluid Compute, where the unified `Invocations` + Active CPU + Provisioned Memory model applies. Throttles, importantly, are *not* a chargeable metric; they're a reliability signal telling you a concurrency ceiling got hit. Details live in the [Functions pricing docs](https://vercel.com/docs/functions/usage-and-pricing) and the [Fluid Compute docs](https://vercel.com/docs/fluid-compute).
+
+## Ship it
+
+Builds have their own little economy, and it took me a minute to realize there are two distinct billing shapes depending on the build machine. Fixed machines (Standard, Enhanced, Turbo) bill per **build minute**. The auto-scaling Elastic machine bills per **CPU minute** instead — because it varies its vCPU count (4 to 30) per build, Vercel charges by duration *times* the vCPUs it assigned. On Hobby you can't use the larger machines and aren't billed for builds at all.
+
+| Metric | What it measures | Unit / how it's billed | What drives it up | How to lower it |
+|---|---|---|---|---|
+| Build Time | Wall-clock duration of one build/deploy | Duration (diagnostic, not its own bill); 45 min hard cap | Large apps, heavy bundling/type-checking, cold caches, big monorepos | Build cache, remote caching, skip unaffected projects |
+| Number of Builds | Count of build events (one per deploy) | Integer count | Frequent pushes, many previews, monorepo projects deploying per push | Skip unaffected projects, Ignored Build Step, fewer redeploys |
+| Build Minutes | Billed compute for Standard/Enhanced/Turbo machines | Per build minute at the machine's rate (Pro from $0.014–$0.126/min) | Long builds, larger machines, On-Demand Concurrency, frequent deploys | Cut duration, prefer Elastic, don't over-provision to Turbo |
+| Build CPU Minutes | Billed compute for the Elastic machine | Per CPU minute (from $0.0035), = duration × assigned vCPUs | Long Elastic builds, CPU/memory-bound work upgrading vCPUs | Cut duration, let Elastic down-size, trim CPU-heavy steps |
+| Artifacts Time Saved | Time avoided by reusing cached task outputs | Aggregate time — **not** billed (higher is better) | More cache hits, shared work, expensive cached tasks | N/A — this is the savings, maximize it |
+| Remote Cache Artifacts | Count of artifacts up/downloaded to the Remote Cache API | Count — **not** billed (charged on size, not count) | Many cacheable tasks, team/CI size, frequent builds | Cache deliberately; stay under per-minute request limits |
+| Remote Cache Total Size | Size of artifacts moved through the Remote Cache | GB — **not** billed (free under fair use) | Caching large outputs (e.g. the whole `.next` folder) | Cache only needed files; scope task `outputs` tightly |
+
+This is where **Turborepo remote caching** earns its keep. The three Artifacts meters are all marked "Priced: No" — Vercel's Remote Cache is free on all plans subject to fair use. What it buys you is build *time*: unchanged tasks replay from the cache instead of rebuilding, which is exactly what "Artifacts Time Saved" measures. Fair-use upload limits are **100 GB/month** on Hobby and **1 TB** on Pro, and uploaded artifacts auto-expire after 7 days. The one trap: don't cache the `.next/cache` folder — it's for development and just bloats your remote cache size. Vercel's [remote caching docs](https://vercel.com/docs/monorepos/remote-caching) cover this.
+
+## Data and platform add-ons
+
+This is the long tail — everything that isn't core request/render/run. I'll group it into one big reference table since most of these are opt-in products you either use or you don't.
+
+| Metric | What it measures | Unit / how it's billed | What drives it up | How to lower it |
+|---|---|---|---|---|
+| Blob Storage | Data stored in your blob store | GB-month (15-min snapshots averaged), regional | Large media, long retention, orphaned old versions | Delete unused blobs (free), compress media, prune promptly |
+| Blob Simple Operations | `head()` calls + cache-miss URL accesses | Count, regional ($0.35–$0.56 per 1M) | Low cache-hit ratio, frequent `head()`, blobs >512 MB | Long `cacheControlMaxAge`, immutable blobs, conditional reads |
+| Blob Advanced Operations | `put`/`upload`/`copy`/`list` actions | Count, regional ($4.50–$7.00 per 1M) | Frequent uploads, multipart (each part counts), unpaginated `list()`, dashboard browsing | Batch/paginate, fewer parts, cache `list()` results |
+| Blob Data Transfer | Outbound download bandwidth | GB, regional ($0.05–$0.117); uploads don't count | Popular/large downloads, low cache-hit, blobs >512 MB | Cache aggressively, serve public assets via browser/CDN |
+| Queue Message Sends | Each publish to a topic | Per API op, 4 KiB chunks; regional ($0.60–$0.96 per 1M); idempotency keys = 2x | High publish throughput, large payloads, idempotency keys | Batch messages, send IDs not blobs, key only when needed |
+| Queue Message Receives | Each consume from a consumer group | Per API op, 4 KiB chunks; 1–10 messages per call | Frequent polling, fan-out across consumer groups | Receive batches of 10, back off empty polls, fewer groups |
+| Queue Message Deletes | Each acknowledgment of a processed message | Per API op, 4 KiB chunks | Volume of processed messages, fan-out | Reduce total messages, trim unnecessary consumer groups |
+| Queue Notifications | Push-mode callback deliveries to your function | Per API op, 4 KiB chunks; max-concurrency = 2x | Push mode, high throughput, retries, fan-out | Use poll mode where cheaper, idempotent consumers |
+| Queue Visibility Changes | Each extension of a message's visibility timeout | Per API op, 4 KiB chunks | Long-running consumers heartbeating timeouts | Longer initial timeout, smaller messages, fewer extensions |
+| Cron Job Invocations | Each time a scheduled cron fires | Billed as a Function Invocation (no separate meter) | Number of crons × schedule frequency | Run no more often than needed, enqueue heavy work to Queues |
+| Drain Volume | Observability data forwarded to drains | $0.50 per 1 GB (Pro), 1 GB increments | Traffic volume, draining previews, verbose logs, no sampling | Drain production only, apply sampling, restrict log sources |
+| Web Analytics Events | Page views + custom events (`track()`) | One event each, pooled team-wide | Traffic, heavy custom-event instrumentation, more projects | `beforeSend()` to exclude routes, trim custom events |
+| Speed Insights Data Points | Web Vital measurements (~3–6 per visit) | One data point per metric; Pro $10/mo per project + per-point | Traffic × 3–6, hard navigations, more enabled projects | Lower `sampleRate`, `beforeSend()`, disable on unused projects |
+| Monitoring data points | One event per request (legacy, being sunset) | $1.20 per 1M events, team-wide | Request volume (no per-request control) | Migrate to Observability Plus; reduce overall requests |
+| Observability Events | Events per request (fans out into up to 5 types) | $1.20 per 1M (Plus); Pro $10/mo base | Traffic × architectural fan-out (middleware, functions, APIs) | Cache to serve 1 event not the chain; scope middleware |
+| Flags Explorer Overrides | Override actions in the Flags Explorer toolbar | One per "apply" click; 150/mo free all plans | Frequent manual flag flipping, one-at-a-time applies | Batch flags into one apply, stay under 150/mo |
+| Flag Requests | Requests reading the flags configuration | $30 per 1M ($0.00003 each); multiple flags, one source = 1 | High traffic reading flags, multiple flag sources per request | Consolidate to one source, evaluate on cached paths |
+| BotID Requests | `checkBotId()` Deep Analysis calls | $1 per 1,000 (Pro/Enterprise); Basic check is free | Deep Analysis on high-traffic or many routes | Deep Analysis only on high-value routes, WAF bypass |
+| Trace Spans | Spans captured via Tracing | One per span; 1M/mo per team, all plans | Broad tracing, `@vercel/otel`, many custom spans, many fetches | Trace selectively, judicious custom spans, sample drains |
+| Private Data Transfer | Egress leaving the Secure Compute network to the public internet | $0.15/GB; VPC-peered traffic is free | DB/API calls over public internet, high egress | Route to AWS over VPC peering, compress, cache externally |
+| Sandbox Creations | Each `Sandbox.create()` microVM | $0.60 per 1M | Many short-lived sandboxes, fresh sandbox per task | Reuse sandboxes, use snapshots |
+| Sandbox Active CPU | CPU time the sandbox actively uses | CPU-hours, $0.128/hr; I/O wait excluded | CPU-bound work, more vCPUs, long compute | Right-size vCPUs, `stop()` promptly, short timeouts |
+| Sandbox Provisioned Memory | Allocated memory × runtime | GB-hours, $0.0212/GB-hr, 1-min minimum | High vCPU/memory, long runtime, idle provisioning | Right-size, stop promptly, snapshots |
+| Sandbox Data Transfer | In/out network (packages, APIs, ports) | GB, $0.15/GB | Large dependency downloads, big datasets, chatty APIs | Snapshots to skip re-downloads, compress, reuse warm sandbox |
+| Sandbox Storage | Snapshot storage | GB-month, $0.08/GB-mo | Many/large snapshots, long retention | Lean snapshots, default 30-day expiry, delete unused |
+
+A few included allowances I want on record: Web Analytics gives Hobby **50,000 events/month** (then a grace period, then a pause; Pro bundles none and bills $3 per 100,000). Speed Insights caps Hobby at **10,000 data points/month** across one project. Trace Spans allow **1,000,000 spans/month per team** on every plan, including Hobby — that one genuinely surprised me. Blob includes **1 GB** of storage, **10,000 simple ops**, **2,000 advanced ops**, and **10 GB** of data transfer on Hobby. And the whole Sandbox surface includes generous Hobby tiers (5,000 creations, 5 CPU-hours, 420 GB-hours, 20 GB transfer) that pause rather than bill when exceeded. Note a couple of these are *not* billed at all — Throttles and the three Artifacts meters are pure signals.
+
+## How to read your own dashboard
+
+Now that the meters make sense, the dashboard reads completely differently. The key UI element is what Vercel calls the **allotment indicator**: for each resource it shows how much you've consumed this cycle and the projected cost. That's your early-warning system — it's how you spot a resource approaching 100% of its allowance *before* it pauses (Hobby) or starts billing on-demand (Pro).
+
+A few things I now do every time I look:
+
+- **Switch the view.** The dashboard offers Count, Project, Region, Ratio, and Average groupings. The **Ratio** view is the one that finds waste — cached vs uncached requests, successful vs errored vs timed-out invocations, uploaded vs downloaded artifacts. A bad cache-hit ratio jumps out instantly.
+
+- **Use the Project and Region breakdowns.** Because many resources are regionally priced, the Region view tells you whether one expensive region is driving a metric. The Project view pinpoints which app is responsible.
+
+- **Look at the last 30 days,** not just today, to catch patterns rather than spikes.
+
+Remember the plan asymmetry while you read: **Pro raises the ceilings** (1 TB vs 100 GB transfer, 10M vs 1M Edge Requests, 16 vs 4 Active CPU hours, and so on) and turns a "pause" into "on-demand billing." On Pro you also get [Spend Management](https://vercel.com/docs/spend-management), which lets you set a dollar cap that either alerts you or auto-pauses deployments — the safety valve Hobby doesn't need because Hobby can't spend.
+
+## An optimization playbook
+
+Reading all fifty meters, the same handful of levers kept reappearing. If I had to compress everything above into a playbook, it's this:
+
+**Cache aggressively.** This is the single highest-leverage move because it hits multiple meters at once. A response served from the CDN cache is a *cache hit* — it doesn't count as a Function Invocation and it doesn't run the function. The same caching that cuts Invocations also cuts Edge Requests' downstream chain and keeps requests from falling through to billed durable ISR/Data Cache reads. One `Cache-Control` header, several meters lower.
+
+**Shrink payloads.** Fast Data Transfer is billed on the *full* size of every response — body, headers, URL, the lot. Smaller pages, trimmed JS/CSS bundles, and returning only the fields an API actually needs all pull this number down directly. Smaller responses also mean fewer 8 KB units when those responses get cached.
+
+**Fewer image variants, longer TTLs.** Every distinct (source × width × quality × format) combination is a separately billable transformation on first request, and each one writes to the global image cache in 8 KB Write Units. Dropping from two formats to one roughly halves transforms; trimming device sizes and qualities cuts them further; and a long cache TTL (up to 31 days) stops you paying to re-transform and re-write the same variants. Lower quality even shrinks the per-fetch 8 KB read/write counts.
+
+**Turborepo remote cache for builds.** Since remote cache artifacts aren't billed, the whole win is build *time* — and on Pro, build time is money (Build Minutes or Build CPU Minutes). Replaying unchanged tasks from the remote cache, skipping unaffected monorepo projects, and not caching `.next/cache` keep builds short.
+
+**Kill non-determinism in cached/regenerated code.** `new Date()` and `Math.random()` in ISR or Data Cache output make every revalidation look "changed," forcing a write even when the meaningful content is identical. Make the output deterministic and those writes drop to zero.
+
+## Closing
+
+What changed for me wasn't a dollar figure — I'm still on Hobby, still paying nothing. What changed is that the usage dashboard stopped being noise. I now read it as my application's *bill of materials*: a precise inventory of every byte transferred, every request processed, every CPU-millisecond spent, every image transformed. Each meter is a sentence about how my code actually behaves in production — where it's chatty, where it's wasteful, where it caches well.
+
+That's the part I didn't anticipate. Understanding the meters didn't just prepare me for an eventual bill; it made me a better builder. A low cache-hit ratio, a function that quietly waits 400 ms on every request, an image config generating four formats nobody asked for — these are *engineering* problems that happen to show up on a billing page. Reading the meters is just reading your own system honestly. And whether the column on the right says "free" or "dollars," that's a skill worth having.

--- a/test/controllers/journal_controller_test.rb
+++ b/test/controllers/journal_controller_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+
+class JournalControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    Post.content_dir = Rails.root.join("test", "fixtures", "files", "journal")
+    Post.reload!
+  end
+
+  teardown do
+    Post.content_dir = nil
+    Post.reload!
+  end
+
+  test "index renders successfully" do
+    get journal_url
+    assert_response :success
+    assert_select "h1", /Journal/
+  end
+
+  test "show renders a published post" do
+    get journal_post_url("sample-post")
+    assert_response :success
+    assert_select "h1", /Sample Post/
+  end
+
+  test "show returns 404 for a draft post" do
+    get journal_post_url("hidden-draft")
+    assert_response :not_found
+  end
+
+  test "show returns 404 for an unknown slug" do
+    get journal_post_url("does-not-exist")
+    assert_response :not_found
+  end
+end

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -4,5 +4,6 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
   test "should get home" do
     get root_url
     assert_response :success
+    assert_select "a[href=?]", journal_path
   end
 end

--- a/test/fixtures/files/journal/hidden-draft.md
+++ b/test/fixtures/files/journal/hidden-draft.md
@@ -1,0 +1,8 @@
+---
+title: Hidden Draft
+date: 2026-05-25
+summary: Should never be public.
+draft: true
+---
+
+Draft body content.

--- a/test/fixtures/files/journal/older-post.md
+++ b/test/fixtures/files/journal/older-post.md
@@ -1,0 +1,8 @@
+---
+title: Older Post
+date: 2026-05-01
+summary: An older summary.
+tags: [gamma]
+---
+
+Older body content for ordering tests.

--- a/test/fixtures/files/journal/sample-post.md
+++ b/test/fixtures/files/journal/sample-post.md
@@ -1,0 +1,9 @@
+---
+title: Sample Post
+date: 2026-05-20
+summary: A sample summary.
+tags: [alpha, beta]
+draft: false
+---
+
+Hello body. This is sample content used by the test suite.

--- a/test/helpers/markdown_helper_test.rb
+++ b/test/helpers/markdown_helper_test.rb
@@ -1,0 +1,16 @@
+require "test_helper"
+
+class MarkdownHelperTest < ActionView::TestCase
+  test "renders markdown headings to html" do
+    assert_includes markdown("# Hello"), "<h1"
+  end
+
+  test "renders tables" do
+    md = "| a | b |\n|---|---|\n| 1 | 2 |"
+    assert_includes markdown(md), "<table"
+  end
+
+  test "blank input returns empty string" do
+    assert_equal "", markdown(nil)
+  end
+end

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -61,4 +61,15 @@ class PostTest < ActiveSupport::TestCase
       assert_includes post.body, "CRLF body content."
     end
   end
+
+  test "reading_time counts prose only, excluding markdown tables" do
+    Dir.mktmpdir do |dir|
+      prose = ([ "word" ] * 200).join(" ")
+      table = "\n\n| A | B |\n|---|---|\n| one | two |\n| three | four |\n"
+      File.write(File.join(dir, "with-table.md"), "---\ntitle: T\ndate: 2026-05-15\n---\n\n#{prose}#{table}")
+      Post.content_dir = Pathname.new(dir)
+      Post.reload!
+      assert_equal 1, Post.find("with-table").reading_time
+    end
+  end
 end

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -29,7 +29,7 @@ class PostTest < ActiveSupport::TestCase
   end
 
   test "parses tags into an array" do
-    assert_equal ["alpha", "beta"], Post.find("sample-post").tags
+    assert_equal [ "alpha", "beta" ], Post.find("sample-post").tags
   end
 
   test "reading_time is at least one minute" do
@@ -43,7 +43,7 @@ class PostTest < ActiveSupport::TestCase
   end
 
   test "recent sorts published posts by date descending" do
-    assert_equal ["sample-post", "older-post"], Post.recent.map(&:slug)
+    assert_equal [ "sample-post", "older-post" ], Post.recent.map(&:slug)
   end
 
   test "find returns nil for an unknown slug" do

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -1,0 +1,64 @@
+require "test_helper"
+require "tmpdir"
+
+class PostTest < ActiveSupport::TestCase
+  setup do
+    Post.content_dir = Rails.root.join("test", "fixtures", "files", "journal")
+    Post.reload!
+  end
+
+  teardown do
+    Post.content_dir = nil
+    Post.reload!
+  end
+
+  test "loads every markdown file in the content dir" do
+    assert_equal 3, Post.all.size
+  end
+
+  test "parses front matter and strips it from the body" do
+    post = Post.find("sample-post")
+    assert_equal "Sample Post", post.title
+    assert_equal "A sample summary.", post.summary
+    assert_includes post.body, "Hello body"
+    refute_includes post.body, "title:"
+  end
+
+  test "slug defaults to the filename without extension" do
+    assert_equal "sample-post", Post.find("sample-post").slug
+  end
+
+  test "parses tags into an array" do
+    assert_equal ["alpha", "beta"], Post.find("sample-post").tags
+  end
+
+  test "reading_time is at least one minute" do
+    assert_operator Post.find("sample-post").reading_time, :>=, 1
+  end
+
+  test "published excludes drafts" do
+    slugs = Post.published.map(&:slug)
+    assert_includes slugs, "sample-post"
+    refute_includes slugs, "hidden-draft"
+  end
+
+  test "recent sorts published posts by date descending" do
+    assert_equal ["sample-post", "older-post"], Post.recent.map(&:slug)
+  end
+
+  test "find returns nil for an unknown slug" do
+    assert_nil Post.find("does-not-exist")
+  end
+
+  test "parses front matter written with CRLF line endings" do
+    Dir.mktmpdir do |dir|
+      crlf = "---\r\ntitle: CRLF Post\r\ndate: 2026-05-15\r\n---\r\n\r\nCRLF body content.\r\n"
+      File.binwrite(File.join(dir, "crlf-post.md"), crlf)
+      Post.content_dir = Pathname.new(dir)
+      Post.reload!
+      post = Post.find("crlf-post")
+      assert_equal "CRLF Post", post.title
+      assert_includes post.body, "CRLF body content."
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds the **Journal** section (`/journal`) — the 3rd live section of the 7-section architecture — as a native file-based blog. Posts are markdown files in `content/journal/*.md` (YAML front matter + body), loaded by a `Post` PORO that mirrors the existing `Achievement` pattern. No database, no Ghost CMS; deploy = publish.
- New HTTP layer: `JournalController` (index + show), routes `/journal` and `/journal/:slug`, warm-cream prose + table styling (`journal.css`). Drafts and unknown slugs return 404.
- Extracts the shared `markdown()` helper out of `WorksHelper` into a dedicated `MarkdownHelper` (now used by both Work and Journal).
- Homepage "Writing" section links the latest article dynamically, replacing the stale "Coming Soon" / "Ghost CMS" copy.
- Publishes the first post, **Understanding Vercel Usage** — a generic, reference-style walkthrough of every meter on the Vercel usage dashboard, sourced from official Vercel docs.
- Wide reference tables break out beyond the prose column (centered, viewport-capped) so they fit on desktop without horizontal scroll; reading-time counts prose only (~12 min).
- `CLAUDE.md` updated: Journal marked live, file-based pattern documented, stale Ghost-CMS references corrected.

## Test plan

- [x] `bin/rails test` — 20 runs, 0 failures (Post model, JournalController, MarkdownHelper + existing suites)
- [x] `bin/rubocop` — 60 files, no offenses
- [x] Browser-verified locally: `/journal` lists the post; the article renders with broken-out tables (no desktop scroll, no page overflow at a 1700px viewport); the homepage links the latest article; draft + unknown slugs 404
- [ ] Sanity-check the post copy and table presentation on the deploy preview

## Notes

- Tables use a centered breakout (`width: min(70rem, 92vw)`) so they fit on desktop without scroll and stay within the viewport on mobile.
- Reading-time excludes markdown table rows (dense reference content), so the estimate reflects prose pacing.