### PR TITLE
chore: import 7 project stories as draft work entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,9 @@ Thumbs.db
 # Playwright MCP screenshots
 .playwright-mcp/
 
+# Claude Code worktrees (agent scratch — regenerated per session)
+/.claude/worktrees/
+
 # Brainstorming specs and implementation plans — local-only working artifacts
 # auto-generated per planning session. Curated documentation lives in docs/*.md.
 /docs/superpowers/

--- a/content/work/earn-auto-reviewer.md
+++ b/content/work/earn-auto-reviewer.md
@@ -1,0 +1,136 @@
+---
+title: Earn Auto Reviewer
+slug: earn-auto-reviewer
+summary: An eight-judge AI panel that evaluates Superteam Earn bounty submissions in parallel — specialized reviewers for security, performance, testing, and more.
+category: AI Agents
+status: Draft
+github_url: https://github.com/RECTOR-LABS/earn-auto-reviewer
+repo_name: RECTOR-LABS/earn-auto-reviewer
+created_at: '2025-12-24'
+featured: false
+technologies:
+- Next.js 15
+- React 19
+- TypeScript
+- Claude 3.5 Haiku
+- OpenRouter
+- Octokit
+github_stars: 0
+github_forks: 0
+---
+
+# Earn Auto Reviewer: Teaching AI to Judge Code
+
+[Superteam Earn](https://earn.superteam.fun) processes hundreds of bounty submissions monthly. Developers submit code, reviewers evaluate it, winners get paid. Simple in theory. Exhausting in practice.
+
+I watched reviewers burn out. Same patterns appearing submission after submission. Missing tests. Poor documentation. Security issues that should be caught automatically. Reviewers spending hours on work that felt mechanical.
+
+What if AI could handle the mechanical parts? Not replace human judgment, but filter and prioritize. Catch the obvious issues. Let humans focus on what matters.
+
+**The Eight-Judge Panel**
+
+One AI reviewer isnt enough. Code quality has dimensions. Security differs from performance differs from documentation. A single prompt trying to evaluate everything produces mediocre results everywhere.
+
+So I built a panel. Eight specialized judges, each an expert in their domain:
+
+- **Architecture Judge** — Structure, patterns, modularity, separation of concerns
+- **Security Judge** — Vulnerabilities, input validation, authentication, data exposure
+- **Performance Judge** — Efficiency, algorithmic complexity, resource usage
+- **UX/DX Judge** — Developer experience, API design, error messages, usability
+- **Testing Judge** — Coverage, edge cases, test quality, mocking strategies
+- **Documentation Judge** — Comments, READMEs, API documentation, clarity
+- **Innovation Judge** — Creativity, novel approaches, problem-solving elegance
+- **DevOps Judge** — Deployment, CI/CD, containerization, infrastructure
+
+Each judge runs in parallel. Eight evaluations happening simultaneously. Thirty seconds total, not thirty seconds times eight.
+
+**The Scoring System**
+
+Raw opinions dont help. Reviewers need actionable data. So each judge produces structured output:
+
+- Numerical score (0-100)
+- Severity-tagged findings (critical, major, minor, suggestion)
+- Specific file and line references where possible
+- Concrete recommendations for improvement
+
+These roll up into four weighted dimensions:
+
+- Code Quality: 40 points
+- Completeness: 30 points
+- Testing: 20 points
+- Innovation: 10 points
+
+Final score maps to letter grades. An A+ submission looks different from a C-. Reviewers can prioritize their queue by grade, focusing human attention where it matters most.
+
+**Token Economics**
+
+AI isnt free. And bounty platforms operate on thin margins. The system needed to be cheap.
+
+Claude 3.5 Haiku through [OpenRouter](https://openrouter.ai) hits the sweet spot. Fast, capable, inexpensive. Each review costs under five cents. At scale, closer to two cents. Thats sustainable for a platform processing thousands of submissions.
+
+But tokens add up with large codebases. A 50,000-line repository cant go through AI raw. Smart optimization was essential:
+
+- Filter boilerplate (node_modules, build artifacts, lock files)
+- Prioritize source code over configuration
+- Summarize rather than include verbose files
+- Chunk large files with overlap for context
+
+The optimizer reduces token usage by 60-80% without meaningful quality loss. The AI sees what matters.
+
+**Real-Time Streaming**
+
+Nobody wants to stare at a loading spinner for thirty seconds. The UI streams analysis as it happens. Watch judges complete one by one. See findings populate in real-time. Progress bars that actually reflect progress.
+
+This was harder than expected. Server-sent events, streaming responses, managing eight parallel processes with unified output. But the experience transforms from "is it working?" to "watching intelligence unfold."
+
+**Why This Matters for Superteam**
+
+Superteam Earn connects builders with bounties across the Solana ecosystem. Quality control is essential — sponsors expect good work, contributors expect fair evaluation.
+
+Manual review doesnt scale. As the platform grows, reviewer burden grows. Eventually something breaks — either review quality drops or response times explode.
+
+Auto Reviewer changes the equation. AI handles first-pass filtering. Obvious rejections get flagged early. Strong submissions surface quickly. Human reviewers spend time on edge cases where judgment matters.
+
+The goal isnt replacing humans. Its amplifying them. One reviewer with AI assistance processes more submissions at higher quality than three reviewers doing everything manually.
+
+**The Technical Stack**
+
+Frontend runs [Next.js 15](https://nextjs.org) with [React 19](https://react.dev) — latest everything because why not. TypeScript throughout. [Tailwind CSS](https://tailwindcss.com) for styling.
+
+Backend uses the GitHub REST API via [Octokit](https://github.com/octokit/octokit.js). Fetches PRs, repositories, commits, branches — whatever URL you throw at it. Parser extracts relevant code and metadata.
+
+AI calls go through OpenRouter to Claude. Structured prompts, JSON responses, parallel execution with Promise.all. Error handling because AI services occasionally hiccup.
+
+Deployment on [Vercel](https://vercel.com) for simplicity. Docker-ready for self-hosting if Superteam wants to run it internally.
+
+**What I Learned**
+
+**Parallel beats sequential.** Eight judges at once instead of one after another. Simple architectural choice, dramatic performance improvement. Always ask: can this be parallel?
+
+**Structured output is essential.** Free-form AI responses vary wildly. JSON schemas with required fields produce consistent, parseable results. Enforce structure at the prompt level.
+
+**Streaming improves perceived performance.** Real progress feels faster than hidden progress. Users tolerate longer waits when they see activity.
+
+**Token optimization is an art.** What to include, what to exclude, how to summarize. The optimizer is as important as the AI itself.
+
+**Specialization beats generalization.** One expert judge per domain outperforms one generalist trying to evaluate everything. Divide and conquer applies to AI too.
+
+**The Bigger Picture**
+
+Code review AI is everywhere now. Copilot does it. Various startups do it. But the eight-judge panel approach — specialized experts operating in parallel — thats different.
+
+Its how human review committees work. Security expert checks security. Performance expert checks performance. Each brings domain depth that generalists lack.
+
+AI can work the same way. Not one model pretending omniscience, but multiple perspectives combining into comprehensive evaluation.
+
+Earn Auto Reviewer is a proof of concept. The pattern applies anywhere code needs assessment at scale. Open source contributions. Job applications. Educational grading. Anywhere human review bottlenecks exist.
+
+---
+
+**Tech Stack:** Next.js 15, React 19, TypeScript, Claude 3.5 Haiku, OpenRouter, Octokit
+
+**Status:** Live and processing submissions
+
+**Links:** [GitHub](https://github.com/RECTOR-LABS/earn-auto-reviewer)
+
+**Cost:** Under 5 cents per review

--- a/content/work/karyachain.md
+++ b/content/work/karyachain.md
@@ -1,0 +1,128 @@
+---
+title: KaryaChain
+slug: karyachain
+summary: Blockchain-based IP protection for Indonesia's creative economy — tamper-proof ownership records and programmable licensing. Built for the OJK-EKRAF hackathon.
+category: Civic Tech
+status: Draft
+github_url: https://github.com/RECTOR-LABS/ojk-ekraf-hackathon
+repo_name: RECTOR-LABS/ojk-ekraf-hackathon
+created_at: '2025-12-24'
+featured: false
+technologies:
+- Next.js 14
+- TypeScript
+- PostgreSQL
+github_stars: 0
+github_forks: 0
+---
+
+# KaryaChain: When Blockchain Meets Creative Rights
+
+Indonesian creators get ripped off constantly. Musicians see their songs on streaming platforms without royalties. Designers find their work copied without attribution. Photographers watch their images spread across the internet with no compensation.
+
+Intellectual property protection in Indonesia is broken. The legal system is slow, expensive, and often ineffective. Creators with legitimate claims give up because enforcement costs more than potential recovery.
+
+The OJK-EKRAF hackathon asked: can blockchain fix this? KaryaChain is my answer.
+
+**The Creative Economy Problem**
+
+Indonesia's creative economy is massive — hundreds of billions in annual output, millions of workers, growing faster than traditional sectors. But IP theft bleeds billions more.
+
+The core issues:
+
+- **Registration is cumbersome** — Government IP offices require physical visits, paper forms, weeks of processing
+- **Proof of creation is weak** — Timestamps can be forged, metadata can be stripped, disputes become he-said-she-said
+- **Enforcement is expensive** — Legal action costs thousands of dollars, beyond most individual creators
+- **Tracking usage is impossible** — Once work is released, creators have no visibility into how it spreads
+
+Blockchain addresses several of these. Not all — technology cant replace legal systems entirely — but enough to make meaningful impact.
+
+**The KaryaChain Solution**
+
+At its core, KaryaChain creates tamper-proof ownership records for creative works.
+
+**Registration Flow:**
+
+1. Creator uploads work (image, audio, video, document)
+2. System generates cryptographic hash — unique fingerprint of the content
+3. Hash is recorded on-chain with creator's wallet address and timestamp
+4. Creator receives ownership certificate with verifiable on-chain proof
+
+This registration is instantaneous, costs pennies in transaction fees, and produces evidence admissible in Indonesian courts (per digital signature regulations).
+
+**Licensing and Monetization:**
+
+Beyond proof of ownership, KaryaChain enables programmable licensing. Creators specify terms:
+
+- Commercial use: yes/no/conditional
+- Attribution requirements
+- Geographic restrictions
+- Duration limits
+- Royalty rates for different use cases
+
+Smart contracts enforce these terms automatically. A business wanting to use a photograph queries the chain, sees the license terms, pays the specified fee, and receives verifiable permission.
+
+**The Technical Architecture**
+
+Built during a hackathon weekend, so architecture prioritized shipping over perfection.
+
+Frontend: [Next.js 14](https://nextjs.org) with TypeScript. Clean submission forms, portfolio views, licensing dashboards. Server components for initial load performance, client components for interactive elements.
+
+Smart contracts: Would ideally be Solana programs, but hackathon timeline pushed toward simpler solutions. Used a hybrid approach — on-chain registration records with off-chain metadata storage.
+
+Verification system: Content hashing using SHA-256 for documents, perceptual hashing for images (tolerates minor modifications). Hash comparison enables detecting derivatives and copies.
+
+Database: PostgreSQL for user accounts, work metadata, licensing history. On-chain data serves as source of truth; database enables fast queries and UX features.
+
+**Why This Matters for Indonesia**
+
+OJK is Indonesia's Financial Services Authority. EKRAF is the creative economy agency. Their joint hackathon signals government interest in blockchain solutions for real problems — not speculation, not DeFi, but practical applications affecting ordinary Indonesians.
+
+KaryaChain demonstrates that interest is justified. Blockchain's properties — immutability, transparency, programmability — map well to IP protection needs. The technology isn't magic, but it's genuinely useful.
+
+If implemented nationally, systems like KaryaChain could:
+
+- Reduce registration friction, increasing formal IP protection rates
+- Create portable proof of ownership that works across jurisdictions
+- Enable automated royalty collection for digital content
+- Provide courts with clear evidence chains for disputes
+
+**The Hackathon Experience**
+
+48 hours to build something meaningful. No sleep, endless coffee, that strange hackathon energy where impossible timelines somehow get met.
+
+The judges cared about practical impact, not technical showmanship. Could this actually help Indonesian creators? Would they use it? Does the blockchain component add real value or is it just buzzword decoration?
+
+Good questions. KaryaChain's answers were convincing enough for recognition. The IP protection use case is legitimate — blockchain genuinely helps here, unlike many forced applications.
+
+**What I Learned**
+
+**Government interest in blockchain is real.** OJK and EKRAF sponsoring this hackathon reflects serious exploration of blockchain applications. Builders who focus on genuine utility — not speculation — have opportunities.
+
+**Indonesian creators desperately need solutions.** Conversations with artists and musicians during the hackathon revealed how pervasive IP theft is. Not edge cases — the default experience for most creators.
+
+**Simple beats complex.** The winning approaches at hackathons are usually the clearest, not the most technically sophisticated. KaryaChain's value proposition fits in one sentence.
+
+**Hybrid architectures work.** Pure on-chain systems have UX challenges. Combining blockchain guarantees with traditional database convenience serves users better.
+
+**The Road Ahead**
+
+KaryaChain is a hackathon prototype. Production deployment would require:
+
+- Security audits of smart contracts
+- Legal validation with Indonesian IP attorneys
+- Integration with existing government registration systems
+- Mobile app for casual creators
+- Partnerships with creative platforms for automated registration
+
+The foundation works. Scaling it requires resources beyond hackathon scope. But the prototype proves the concept — blockchain-based IP protection for Indonesian creators isn't theoretical; it's buildable.
+
+---
+
+**Tech Stack:** Next.js 14, TypeScript, PostgreSQL, Blockchain (hybrid architecture)
+
+**Status:** Hackathon Prototype
+
+**Links:** [GitHub](https://github.com/RECTOR-LABS/ojk-ekraf-hackathon)
+
+**Focus:** IP rights management for Indonesian creative economy

--- a/content/work/medichain-ai.md
+++ b/content/work/medichain-ai.md
@@ -1,0 +1,138 @@
+---
+title: MediChain AI
+slug: medichain-ai
+summary: Five specialized AI agents collaborating through knowledge graphs for transparent, evidence-based medical diagnostics. Built for the ASI Agents Track.
+category: AI Agents
+status: Draft
+github_url: https://github.com/RECTOR-LABS/asi-agents-track
+repo_name: RECTOR-LABS/asi-agents-track
+created_at: '2025-12-24'
+featured: false
+technologies:
+- Python
+- Fetch.ai uAgents
+- SingularityNET MeTTa
+- Agentverse
+- "ASI:One"
+github_stars: 0
+github_forks: 0
+---
+
+# ASI Agents Track: When Five AI Agents Diagnose Better Than One
+
+Twelve million Americans get misdiagnosed every year. Forty billion dollars in healthcare costs. Preventable suffering, preventable deaths. The medical system is overwhelmed, and AI could help — if we build it right.
+
+The ASI Agents Track hackathon asked a provocative question: what if autonomous AI agents could work together on complex problems? I chose healthcare diagnostics. Not because I think AI should replace doctors, but because misdiagnosis is often a symptom of information overload and time pressure. Things AI could address.
+
+The result: MediChain AI — five specialized agents collaborating through knowledge graphs to deliver transparent, evidence-based diagnostic assessments.
+
+**Why Multi-Agent?**
+
+Single-model AI has a problem. Ask ChatGPT to diagnose your symptoms and you get confident-sounding answers with no transparency. Why does it think you have condition X? What evidence supports that conclusion? What alternatives did it consider?
+
+Multi-agent systems fix this. Each agent specializes. Each produces traceable reasoning. The combination is greater than any individual part.
+
+MediChain deploys five agents:
+
+- **Coordinator Agent** — Routes incoming requests to appropriate specialists
+- **Patient Intake Agent** — Extracts symptoms through natural language conversation
+- **Knowledge Graph Agent** — Performs diagnostic reasoning using MeTTa symbolic logic
+- **Symptom Analysis Agent** — Assesses urgency, detects red flags, identifies emergencies
+- **Treatment Recommendation Agent** — Validates safety, checks contraindications, suggests evidence-based care
+
+Each agent has a narrow focus. Each does its job well. Together they simulate a multi-disciplinary medical team.
+
+**The Knowledge Graph Difference**
+
+Most AI diagnostics are black boxes. Neural networks that correlate symptoms to conditions without explaining why.
+
+MediChain uses [SingularityNET's MeTTa](https://singularitynet.io) — a symbolic reasoning system that makes logic chains explicit. When the system concludes "possible pneumonia," you can trace the reasoning:
+
+- Patient reports: cough, fever, chest pain
+- Knowledge base: these symptoms correlate with respiratory infections
+- Differential: pneumonia, bronchitis, COVID-19 have highest match
+- Risk factors: patient age and smoking history increase pneumonia probability
+- Recommendation: chest X-ray to confirm, urgent care advised
+
+Transparent reasoning builds trust. Doctors can review the logic. Patients understand the assessment. Nobody has to take the AI's word blindly.
+
+**Safety First**
+
+Healthcare AI without safety validation is dangerous. MediChain includes a 14-scenario input validation system:
+
+- Emergency detection (chest pain + shortness of breath = call 911)
+- Mental health crisis identification (suicidal ideation triggers crisis resources)
+- Inappropriate request filtering (prescription requests, illegal guidance)
+- Red flag symptoms (sudden severe headache, unilateral weakness)
+
+The system knows its limits. Not every question should be answered by an AI. Some need immediate human intervention. MediChain recognizes these and responds appropriately.
+
+**The Technical Stack**
+
+Built on [Fetch.ai's uAgents framework](https://fetch.ai) — Python-based autonomous agent development. Each agent runs independently, communicates through standardized protocols, gets deployed to the Agentverse cloud platform.
+
+Knowledge base v2.0 contains:
+- 25 medical conditions with diagnostic criteria
+- 450+ medical facts for reasoning
+- 88+ contraindication rules
+- Lab test recommendations per condition
+- Imaging requirements and urgency classifications
+
+All grounded in CDC and WHO guidelines. Not hallucinated medical advice — evidence-based protocols encoded as symbolic logic.
+
+Deployment runs on VPS with Agentverse mailbox connectivity. Users interact through the ASI:One chat interface. Type symptoms, receive assessment, follow-up questions as needed.
+
+**The Testing Challenge**
+
+Medical AI requires serious validation. Lives could depend on it (even as a hackathon demo, the standard matters).
+
+169 tests covering:
+- Core diagnostic accuracy (does condition X produce correct assessment?)
+- Edge cases (unusual symptom combinations)
+- Safety scenarios (all 14 validation cases)
+- Contraindication checking (45+ drug interaction rules)
+- Emergency detection (zero false negatives allowed)
+
+84% core coverage. Zero critical bugs. All emergency scenarios validated. Not production-ready — this is a hackathon prototype — but rigorously tested within that scope.
+
+**What Multi-Agent Systems Teach**
+
+Building MediChain changed how I think about AI architecture.
+
+**Specialization beats generalization.** Five focused agents outperform one general-purpose agent. Domain expertise matters, even for AI.
+
+**Transparency requires structure.** You cant explain a neural network's reasoning, but you can explain symbolic logic chains. Architecture constrains what's possible.
+
+**Safety is a feature, not an afterthought.** Building safety validation from day one shapes the entire system design. Retrofitting safety doesnt work.
+
+**Agents are the future.** The ASI vision — Artificial Superintelligence through agent collaboration — makes more sense after building this. Complex problems decompose into agent-solvable subproblems.
+
+**The Ethical Boundary**
+
+MediChain is not medical advice. The README states it clearly: "hackathon demonstration project—not approved for actual medical use."
+
+This matters. Healthcare AI has real consequences. People trust technology. Irresponsible deployment kills people.
+
+What MediChain demonstrates is possibility. If hackathon code with 25 conditions can produce transparent, evidence-based assessments, imagine what properly funded, clinically validated systems could do.
+
+The gap between demo and deployment is massive — FDA approval, clinical trials, liability frameworks, physician integration. But the technical foundation works. Multi-agent diagnostic reasoning is viable.
+
+**The Bigger Picture**
+
+ASI — Artificial Superintelligence — sounds like science fiction. But the path isnt a single godlike AI. Its ecosystems of specialized agents, each contributing unique capabilities, coordinating toward goals no individual could achieve.
+
+MediChain is one tiny example. Healthcare diagnostics. Five agents. One knowledge graph. But the pattern scales.
+
+Financial analysis agents collaborating with risk assessment agents. Legal research agents working with case strategy agents. Scientific hypothesis agents coordinating with experimental design agents.
+
+The hackathon project points toward that future. Not superintelligence as a single entity, but superintelligence as emergent collaboration.
+
+---
+
+**Tech Stack:** Python, Fetch.ai uAgents, SingularityNET MeTTa, Agentverse, ASI:One
+
+**Status:** Deployed for ASI Agents Track Hackathon
+
+**Links:** [GitHub](https://github.com/RECTOR-LABS/asi-agents-track)
+
+**Coverage:** 5 agents • 25 conditions • 169 tests • 84% coverage

--- a/content/work/meteora-fee-routing.md
+++ b/content/work/meteora-fee-routing.md
@@ -1,0 +1,146 @@
+---
+title: Meteora Fee Routing
+slug: meteora-fee-routing
+summary: A permissionless Anchor program for programmable fee distribution on Solana, integrated with Meteora DAMM V2 pools.
+category: DeFi
+status: Draft
+github_url: https://github.com/rz1989s/meteora-cp-amm-fee-routing
+repo_name: rz1989s/meteora-cp-amm-fee-routing
+created_at: '2025-12-24'
+featured: false
+technologies:
+- Rust
+- Anchor
+- Solana
+- SPL Token
+github_stars: 0
+github_forks: 0
+---
+
+# Meteora Fee Routing: Programmable DeFi Revenue Streams
+
+[Meteora](https://meteora.ag) is one of Solana's most sophisticated DEXes. Their DAMM (Dynamic Automated Market Maker) V2 pools handle significant volume with innovative mechanisms for liquidity providers.
+
+But DeFi protocols face a constant challenge: sustainable revenue. Trading fees generate income, but directing that income — to treasuries, to stakers, to partners — requires custom smart contract work for each use case.
+
+Meteora Fee Routing creates programmable fee distribution. An [Anchor](https://www.anchor-lang.com) program that sits between trading fees and their destinations, routing funds according to configurable rules.
+
+**The Fee Distribution Problem**
+
+When a trade happens on a DEX, fees get collected. Simple enough. But where do those fees go?
+
+- Protocol treasury? Which wallet?
+- Stakers? How proportionally?
+- Liquidity providers? Which ones?
+- Partners? What split?
+
+Each protocol implements custom logic. Each partnership requires new code. Each change means redeployment, audits, coordination.
+
+Fee Routing abstracts this. Define routing rules declaratively. Fees flow according to rules automatically. No custom contract work per use case.
+
+**The Architecture**
+
+The Anchor program accepts fees and distributes them according to configured routes:
+
+**Route Configuration:**
+```
+Route {
+  destination: PublicKey,
+  percentage: u16,  // basis points
+  conditions: Vec<Condition>
+}
+```
+
+Multiple routes per pool. Percentages must sum to 10,000 (100%). Conditions enable dynamic behavior — time-based splits, volume thresholds, holder requirements.
+
+**Execution Flow:**
+1. Trading fees accumulate in fee vault
+2. Anyone can trigger distribution (permissionless)
+3. Program reads route configuration
+4. Fees split and transferred to destinations
+5. Distribution event logged for tracking
+
+Gas-efficient through batched transfers. Permissionless execution means anyone can trigger distribution — no central operator required.
+
+**Why Permissionless Matters**
+
+Traditional fee distribution requires trusted operators. Someone has to call the distribute function. That someone has power — they could delay distribution, front-run it, or simply neglect it.
+
+Permissionless distribution eliminates this. Anyone can trigger it. Incentives align through small caller rewards — you get a tiny cut for initiating distribution. In practice, bots handle it automatically.
+
+This is subtle but important. DeFi should minimize trust assumptions. Every trusted party is a potential point of failure.
+
+**Use Cases**
+
+**Protocol Revenue Sharing:**
+Partner protocols can receive automatic fee splits. Integrate with Meteora, receive 10% of fees from your users. No manual accounting, no trust required.
+
+**Staker Rewards:**
+Token stakers receive proportional fee distribution. Routes update based on staking snapshots. Rewards flow without intervention.
+
+**Multi-Treasury Management:**
+Large protocols with multiple treasuries (operations, development, community) can route fees appropriately without consolidating to single wallets.
+
+**Time-Based Transitions:**
+Launch phases might route fees differently than steady state. Routes can include time conditions — 100% to liquidity bootstrapping initially, transitioning to 70/30 treasury/stakers after launch.
+
+**The Technical Details**
+
+Written in [Rust](https://www.rust-lang.org) using Anchor framework. Account structures are carefully designed for gas efficiency:
+
+- Route configs stored in PDA accounts
+- Fee vaults use SPL Token standard
+- Distribution logs enable off-chain analytics
+- Admin functions require multi-sig for safety
+
+The program handles edge cases:
+- Rounding dust goes to designated fallback
+- Failed transfers don't block other routes
+- Pausing is possible but requires governance approval
+
+Testing includes:
+- Unit tests for arithmetic correctness
+- Integration tests against Meteora DAMM pools
+- Fuzzing for unexpected inputs
+- Economic simulations for game-theoretic attacks
+
+**Integration with Meteora DAMM V2**
+
+Meteora's pools can designate fee routing programs as fee receivers. Instead of fees going directly to a treasury, they go to the router, which distributes according to rules.
+
+This means existing pools can adopt programmable fee distribution without migration. Point the fee receiver to the router. Configure routes. Done.
+
+The composability is powerful. Meteora doesn't need to implement every fee distribution pattern. The router handles it. Meteora focuses on trading mechanics; routing handles distribution mechanics.
+
+**What I Learned**
+
+**DeFi is plumbing.** The exciting parts (trading, yields) depend on boring parts (fee collection, distribution). Infrastructure matters more than flashy features.
+
+**Permissionless is hard.** Removing trust assumptions requires careful mechanism design. Incentive alignment, attack resistance, failure handling — all more complex than trusted alternatives.
+
+**Anchor is productive.** Rust + Anchor enables rapid Solana development. Type safety catches errors. Generated clients reduce frontend friction. The ecosystem has matured significantly.
+
+**Gas efficiency compounds.** Saving 1000 compute units per distribution adds up over thousands of distributions. Optimization matters for high-frequency operations.
+
+**The Broader Pattern**
+
+Fee routing is one example of programmable money flow. The pattern generalizes:
+
+- Royalty distribution for NFTs
+- Revenue sharing for DAOs
+- Subscription payment splitting
+- Grant disbursement automation
+
+Any scenario where funds need to move from sources to destinations according to rules can benefit from routing infrastructure.
+
+Meteora Fee Routing is purpose-built for their ecosystem. But the architectural pattern — declarative rules, permissionless execution, composable integration — applies broadly.
+
+---
+
+**Tech Stack:** Rust, Anchor, Solana, SPL Token
+
+**Status:** Integrated with Meteora DAMM V2
+
+**Links:** [GitHub](https://github.com/rz1989s/meteora-cp-amm-fee-routing)
+
+**Purpose:** Permissionless fee routing for Solana DeFi protocols

--- a/content/work/pnode-pulse.md
+++ b/content/work/pnode-pulse.md
@@ -1,0 +1,144 @@
+---
+title: pNode Pulse
+slug: pnode-pulse
+summary: Real-time monitoring dashboard for Xandeum's decentralized storage network — 200+ nodes across 10+ countries, with health scoring and predictive alerts.
+category: Infrastructure
+status: Draft
+github_url: https://github.com/RECTOR-LABS/pnode-pulse
+repo_name: RECTOR-LABS/pnode-pulse
+created_at: '2025-12-24'
+featured: false
+technologies:
+- Next.js 14
+- TypeScript
+- TimescaleDB
+- Redis
+- tRPC
+- Prisma
+- Docker
+github_stars: 0
+github_forks: 0
+---
+
+# pNode Pulse: Watching 200 Nodes Sleep, Wake, and Sometimes Die
+
+Decentralized storage is the future. Everybody says so. But nobody talks about the boring part — actually monitoring hundreds of nodes scattered across the globe, making sure they stay online, tracking their performance, predicting when theyre about to fail.
+
+[Xandeum](https://xandeum.com) is building decentralized storage on Solana. Their pNode network spans 200+ nodes across 10+ countries. Beautiful vision. Operational nightmare without proper tooling.
+
+I built that tooling.
+
+**The Visibility Problem**
+
+Running a distributed network blind is terrifying. Nodes go down. Storage fills up. Version mismatches cause consensus issues. IP addresses change. And without visibility, you dont know until users complain.
+
+The Xandeum team needed answers to basic questions:
+
+- How many nodes are actually online right now?
+- Which nodes are falling behind on updates?
+- Where is storage capacity concentrated?
+- Which nodes are about to run out of disk space?
+- Whats the overall network health?
+
+Before pNode Pulse, answering these required SSH-ing into individual nodes or parsing raw gossip protocol data. Not sustainable at scale.
+
+**Real-Time Everything**
+
+The dashboard updates live. WebSocket connections stream metrics as they change. No refresh buttons. No stale data. Watch a node come online and see the number tick up immediately.
+
+This sounds simple but required careful architecture:
+
+- **Collector Worker** — Continuously polls the Xandeum gossip protocol, gathering node states, metrics, connectivity data
+- **TimescaleDB** — Time-series database storing historical metrics for trend analysis and predictions
+- **Redis Cache** — Frequently accessed data cached for instant dashboard loads
+- **WebSocket Layer** — Pushes updates to connected clients in real-time
+
+The collector runs on a tight loop. Every node gets checked regularly. Changes propagate through Redis to the WebSocket layer to every connected dashboard.
+
+**Network Health Scoring**
+
+Raw metrics overwhelm. Operators need signal, not noise. So I built a health scoring system.
+
+Each node gets graded A through F based on:
+
+- Uptime percentage (how often its been online)
+- Storage utilization (too full is bad, too empty suggests problems)
+- Version currency (running outdated software is risky)
+- Response latency (slow nodes hurt network performance)
+- Peer connectivity (isolated nodes cant participate)
+
+Individual scores roll up into network-wide health. "The network is an A-" communicates more than pages of metrics. When health drops to B or C, operators know to investigate.
+
+**The Node Graveyard**
+
+Nodes die. Its inevitable in any distributed system. Hardware fails, operators abandon projects, network conditions change.
+
+pNode Pulse tracks these deaths. The "graveyard" shows nodes that went offline and never returned. Time of death. Last known metrics. Geographic location.
+
+Morbid? Maybe. Useful? Absolutely. Patterns in node deaths reveal systemic issues. If nodes in a specific region keep dying, maybe theres an infrastructure problem. If nodes running version X die more often, maybe thats a buggy release.
+
+The graveyard turns individual failures into collective intelligence.
+
+**Geographic Distribution**
+
+Where are the nodes? This matters for decentralization and resilience.
+
+The dashboard shows a global map — node density by country and region. If 80% of storage is in one country, thats a centralization risk. Diversification matters for fault tolerance.
+
+Current Xandeum stats: 200+ nodes across 10+ countries with 5+ TB aggregate capacity. Not bad for an early network. The visualization helps the team identify gaps and target expansion efforts.
+
+**Predictive Alerts**
+
+Monitoring tells you what happened. Prediction tells you whats about to happen.
+
+Using historical trends from TimescaleDB, pNode Pulse forecasts:
+
+- Storage exhaustion dates (when will this node run out of disk?)
+- Uptime degradation patterns (is this node getting flaky?)
+- Growth projections (how fast is network capacity expanding?)
+
+Operators get alerts before problems become crises. "Node X will exhaust storage in 7 days" is actionable. "Node X is full" is too late.
+
+**The Technical Stack**
+
+Frontend is [Next.js 14](https://nextjs.org) with TypeScript and [Tailwind CSS](https://tailwindcss.com). Charts use [Recharts](https://recharts.org) because it handles time-series data well. [React Query](https://tanstack.com/query) manages data fetching and caching.
+
+Backend uses [tRPC](https://trpc.io) for type-safe API routes. [Prisma](https://prisma.io) as the ORM talking to PostgreSQL. TimescaleDB extension for efficient time-series queries. Redis for hot data caching.
+
+Deployment is Docker Compose — easy to spin up for development, easy to deploy for production. The whole stack runs on a single modest server despite handling real-time data from 200+ nodes.
+
+**Version Distribution Analytics**
+
+Software updates in distributed systems are chaos. Some nodes update immediately. Others lag behind for months. Version fragmentation causes compatibility issues.
+
+The dashboard shows version distribution across the network. How many nodes run v1.2.3 versus v1.2.2? Is the latest version being adopted? Are there stragglers on ancient releases?
+
+This visibility helps the Xandeum team coordinate upgrades. They can identify operators running old versions and reach out directly. They can see if a new release is causing problems (adoption stalls = something wrong).
+
+**What I Learned**
+
+**Time-series databases are magic.** Regular databases choke on high-frequency metric data. TimescaleDB handles millions of data points with sub-second queries. Right tool, massive difference.
+
+**Real-time adds complexity.** WebSockets, connection management, state synchronization — significant engineering overhead. Only add real-time when it genuinely matters. For network monitoring, it matters.
+
+**Aggregation is interpretation.** The health scoring required endless tuning. What weights? What thresholds? What matters most? Technical decisions disguised as product decisions.
+
+**Historical data enables prediction.** Cant forecast without history. Store everything, compress old data, query intelligently. Future you will thank past you.
+
+**Building for Eternity**
+
+Xandeum is trying to build permanent storage infrastructure. Data that lasts decades. Networks that outlive their creators.
+
+pNode Pulse is a small piece of that vision. Making sure the nodes stay healthy, the network stays decentralized, the storage stays accessible. Monitoring infrastructure for infrastructure.
+
+Not glamorous work. Nobody tweets about dashboards. But without visibility, distributed systems drift toward failure. Pulse keeps Xandeum honest — 200 nodes, 10 countries, 5 terabytes, one dashboard to watch them all.
+
+---
+
+**Tech Stack:** Next.js 14, TypeScript, TimescaleDB, Redis, tRPC, Prisma, Docker
+
+**Status:** Live, monitoring 200+ nodes
+
+**Links:** [GitHub](https://github.com/RECTOR-LABS/pnode-pulse)
+
+**Coverage:** 200+ nodes • 10+ countries • 5+ TB capacity

--- a/content/work/sanctum-gateway.md
+++ b/content/work/sanctum-gateway.md
@@ -1,0 +1,155 @@
+---
+title: Sanctum Gateway
+slug: sanctum-gateway
+summary: Transaction analytics that translate cryptic Solana transactions into human-readable insights for the Sanctum ecosystem.
+category: Developer Tools
+status: Draft
+github_url: https://github.com/RECTOR-LABS/sanctum-gateway-track
+repo_name: RECTOR-LABS/sanctum-gateway-track
+created_at: '2025-12-24'
+featured: false
+technologies:
+- TypeScript
+- Next.js
+- tRPC
+- PostgreSQL
+- Solana Web3.js
+github_stars: 0
+github_forks: 0
+---
+
+# Sanctum Gateway Track: Making Sense of Solana Transactions
+
+Solana transactions are cryptic. Raw instruction data, nested program calls, compressed logs that require decoder rings to interpret. Even experienced developers struggle to understand what happened in complex transactions.
+
+[Sanctum](https://sanctum.so) operates critical DeFi infrastructure on Solana — liquid staking, validator routing, the Infinity pool. Their users and partners need to understand transaction flows, verify operations completed correctly, and debug when things go wrong.
+
+Sanctum Gateway Track provides that understanding. Transaction analytics that translate chain gibberish into human-readable insights.
+
+**The Readability Problem**
+
+Query any Solana transaction through standard explorers. You'll see:
+
+- Program IDs (32-byte base58 strings)
+- Instruction data (hex blobs)
+- Account arrays (more 32-byte strings)
+- Log messages (program-specific formats)
+
+Understanding what actually happened requires:
+- Knowing which program ID maps to which protocol
+- Having the IDL to decode instruction data
+- Understanding the protocol's account model
+- Parsing log messages according to program-specific conventions
+
+This is exhausting. Even builders working daily with Solana transactions find themselves confused. End users have zero chance.
+
+**The Gateway Approach**
+
+Sanctum Gateway Track processes raw transactions and produces structured, readable output:
+
+**Action Identification** — "This transaction staked 100 SOL through Sanctum's validator router"
+
+**Account Labeling** — "The token account at abc...xyz belongs to wallet def...uvw and holds USDC"
+
+**Flow Visualization** — "SOL moved from User → Router → Validator Pool, receiving stSOL in return"
+
+**Success/Failure Analysis** — "Transaction succeeded but inner instruction #3 returned an error that was caught"
+
+The raw data is still available. But now it's annotated, organized, labeled. Understanding happens in seconds instead of minutes.
+
+**Technical Architecture**
+
+The system ingests transaction data from Solana RPC nodes. Parsers decode instructions using protocol-specific IDLs. Analyzers classify transaction types and extract semantic meaning.
+
+**Parser Layer:**
+- Anchor IDL integration for typed instruction decoding
+- Native program support (System, Token, Associated Token)
+- Sanctum-specific decoders for their proprietary programs
+- Fallback raw display when schemas unavailable
+
+**Analysis Layer:**
+- Transaction type classification (stake, unstake, swap, transfer, etc.)
+- Cross-reference with known addresses (labeled accounts)
+- Fee calculation and cost attribution
+- Multi-instruction flow reconstruction
+
+**Presentation Layer:**
+- JSON API for programmatic access
+- Web dashboard for visual exploration
+- Exportable reports for documentation/compliance
+
+Built with [TypeScript](https://www.typescriptlang.org) throughout. [Next.js](https://nextjs.org) frontend, tRPC API routes, PostgreSQL for caching and historical queries.
+
+**Why Sanctum Needed This**
+
+Sanctum handles significant volume — hundreds of millions in TVL, thousands of daily transactions. When something goes wrong, support teams need to quickly understand what happened.
+
+Before Gateway Track:
+1. User reports issue
+2. Support requests transaction signature
+3. Engineer manually decodes transaction
+4. 30 minutes later: "Oh, the slippage tolerance was exceeded"
+
+After Gateway Track:
+1. User reports issue
+2. Support pastes transaction signature
+3. Dashboard immediately shows: "Swap failed: slippage exceeded, user received 0 tokens"
+4. Resolution in 2 minutes
+
+For integration partners, the API enables automated monitoring. Their systems query transaction status, receive structured data, and react programmatically. No human interpretation required.
+
+**The Labeling Challenge**
+
+Addresses are meaningless without context. "GnCaQ9WVN..." tells you nothing. "Sanctum Validator Router Program" tells you everything.
+
+Building a comprehensive address label database is ongoing work:
+- Official program deployments (verified from protocol docs)
+- Known wallets (treasury addresses, team multisigs)
+- Protocol infrastructure (pools, vaults, escrows)
+- Ecosystem contracts (DEXes, bridges, oracles)
+
+Labels accumulate over time. Each new label improves readability for every transaction involving that address.
+
+**Multi-Instruction Complexity**
+
+Simple transactions are easy. Send SOL from A to B. One instruction, obvious meaning.
+
+Sanctum transactions are complex. A single stake operation might involve:
+1. Create associated token account
+2. Approve token transfer
+3. Invoke validator router
+4. Route to specific validator
+5. Mint liquid staking token
+6. Transfer staking token to user
+
+Understanding this requires following the entire chain, recognizing intermediate steps, and summarizing the overall action.
+
+Gateway Track handles this through instruction graph analysis. It identifies entry points, traces execution flow, and collapses complexity into meaningful summaries while preserving detail for those who need it.
+
+**What I Learned**
+
+**Every protocol is different.** No universal decoder handles all Solana programs. Each protocol has quirks, conventions, undocumented behaviors. Supporting a new protocol means learning its specific patterns.
+
+**Labels are surprisingly valuable.** The simple act of naming things transforms usability. Technical work on decoders matters less than the humble label database.
+
+**Historical context helps.** Some transaction interpretation requires knowing prior state. "This unstake withdrew 50% of position" only makes sense if you know the position size before.
+
+**Developers need this too.** Initially built for end users, but developers became heavy users. Debugging complex transactions is universally painful.
+
+**The Broader Application**
+
+Transaction analytics isn't Sanctum-specific. Every Solana protocol needs it. DeFi, NFTs, gaming — all have complex transactions that benefit from interpretation.
+
+Gateway Track's architecture is generalizable. New parser plugins for new protocols. Expanded label databases. The same analysis patterns apply across ecosystems.
+
+Maybe this becomes a product. Maybe it stays infrastructure for Sanctum. Either way, the problem — making blockchain transactions readable — isn't going away. If anything, it gets worse as transactions get more complex.
+
+---
+
+**Tech Stack:** TypeScript, Next.js, tRPC, PostgreSQL, Solana Web3.js
+
+**Status:** Live for Sanctum ecosystem
+
+**Links:** [GitHub](https://github.com/RECTOR-LABS/sanctum-gateway-track)
+
+**Purpose:** Transaction analytics and insights for Solana developers

--- a/content/work/superteam-legends.md
+++ b/content/work/superteam-legends.md
@@ -1,0 +1,121 @@
+---
+title: Superteam Legends
+slug: superteam-legends
+summary: A digital hall of fame for the Solana ecosystem's most impactful contributors — community-nominated, peer-validated.
+category: Community
+status: Draft
+github_url: https://github.com/rz1989s/st-legends
+repo_name: rz1989s/st-legends
+created_at: '2025-12-24'
+featured: false
+technologies:
+- Next.js
+- TypeScript
+- Tailwind CSS
+github_stars: 0
+github_forks: 0
+---
+
+# Superteam Legends: Honoring the Builders Who Came Before
+
+Every ecosystem has its heroes. The early believers. The tireless contributors. The builders who shipped when nobody was watching, who stayed when the market crashed, who mentored newcomers and strengthened community bonds.
+
+[Solana](https://solana.com) has many. The Superteam network — thousands of contributors across dozens of countries — has produced remarkable people. But where do we celebrate them? Where do new builders learn about those who paved the way?
+
+Superteam Legends is that place. A digital hall of fame for the Solana ecosystem's most impactful contributors.
+
+**The Recognition Gap**
+
+Crypto moves fast. Last year's hero becomes this year's footnote. Contributors who spent thousands of hours building critical infrastructure get forgotten as attention shifts to the next shiny thing.
+
+This matters beyond sentiment. New builders need role models. They need to see what's possible, who did it before, what paths exist. Without visible success stories, the ecosystem feels like a lottery rather than a meritocracy.
+
+Superteam Legends addresses this by making contributions visible, permanent, and discoverable.
+
+**What Makes a Legend**
+
+Not everyone qualifies. The hall of fame has criteria:
+
+- **Sustained contribution** — Not one-off projects, but ongoing commitment over months or years
+- **Ecosystem impact** — Work that benefited the broader Solana community, not just personal gain
+- **Community recognition** — Respected by peers, mentioned positively in ecosystem discussions
+- **Verifiable track record** — GitHub contributions, hackathon wins, protocol launches, educational content
+
+Legends emerge through community nomination and validation. This isn't an appointed list — it's collective recognition of genuine impact.
+
+**The Profile System**
+
+Each legend gets a dedicated profile showcasing:
+
+- **Background** — Who they are, how they entered the ecosystem
+- **Key contributions** — Projects built, protocols launched, communities created
+- **Impact metrics** — Where available, quantified outcomes (TVL influenced, users served, developers mentored)
+- **Timeline** — When they joined, major milestones, ongoing work
+- **Recognition** — Awards, grants, community acknowledgments
+
+Profiles tell stories. Not just "built X protocol" but the journey — challenges overcome, lessons learned, evolution over time.
+
+**Community Curation**
+
+Anyone can nominate a potential legend. Nominations include:
+
+- Nominee name and background
+- Specific contributions with evidence
+- Impact assessment
+- Community endorsements
+
+Existing legends vote on nominations. Unanimous approval adds someone to the hall of fame. This prevents gaming — you need genuine peer recognition, not just self-promotion.
+
+**The Technical Build**
+
+Frontend uses [Next.js](https://nextjs.org) with [TypeScript](https://www.typescriptlang.org). Static generation for profile pages — fast loads, SEO-friendly, works without JavaScript.
+
+Data layer is intentionally simple. JSON files for profiles, cached at build time. No complex backend for what's essentially a curated directory. Updates happen through pull requests, reviewed by maintainers.
+
+[Tailwind CSS](https://tailwindcss.com) handles styling. Clean, minimal aesthetic that puts focus on the legends themselves rather than design flourishes.
+
+Future versions could add on-chain verification — linking Solana wallet addresses to GitHub contributions, proving ownership of deployed programs, NFT badges for legends. But the MVP prioritizes content over features.
+
+**Why This Matters**
+
+Culture shapes ecosystems. Solana's culture of building, shipping, and supporting each other didn't happen accidentally. It was created by specific people making specific choices.
+
+Superteam Legends preserves that culture. When someone new joins and asks "what does good look like here?" we can point to specific examples. Real people with real journeys, not abstract ideals.
+
+It also creates aspiration. Seeing peers recognized motivates contribution. The path from newcomer to legend becomes visible and achievable.
+
+**The Broader Vision**
+
+Superteam Legends started focused on Solana, but the pattern generalizes. Every open-source community, every protocol, every DAO needs recognition infrastructure.
+
+Contributors are the lifeblood of decentralized ecosystems. Without them, protocols are just code. With them, they're movements. Recognizing contributions sustains motivation over the long haul.
+
+Maybe other ecosystems build similar halls of fame. Maybe this becomes a template. The specific implementation matters less than the principle: honor your builders, and more builders will come.
+
+**Lessons Learned**
+
+**Curation beats volume.** A small list of genuinely impactful people outperforms a large list of everyone who ever contributed. Quality over quantity creates aspiration.
+
+**Stories beat metrics.** Numbers prove impact, but stories inspire action. The combination works best.
+
+**Community validation matters.** Self-nomination invites gaming. Peer nomination invites respect. Let communities decide who deserves recognition.
+
+**Start simple.** JSON files and static pages work fine. Dont over-engineer recognition infrastructure. Ship something, improve later.
+
+**Building for Legacy**
+
+The best builders don't work for recognition. They work because the work matters. But recognition shouldn't be accidental. Ecosystems that celebrate their contributors attract more contributors.
+
+Superteam Legends is a small project — profile pages and a nomination system. But it represents something larger: intentional culture-building in decentralized communities.
+
+The legends recognized today were unknowns once. The unknowns today could be legends tomorrow. That journey should be visible, celebrated, and available to everyone.
+
+---
+
+**Tech Stack:** Next.js, TypeScript, Tailwind CSS, Static Generation
+
+**Status:** Live
+
+**Links:** [GitHub](https://github.com/rz1989s/st-legends)
+
+**Purpose:** Superteam Hall of Fame for Solana ecosystem contributors


### PR DESCRIPTION
## What

- Imports **7 previously-unpublished project stories** into `content/work/` as drafts — they'd been sitting in the retired Rails `tmp/` dir since Dec 2025: MediChain AI, Sanctum Gateway, Meteora Fee Routing, pNode Pulse, Superteam Legends, KaryaChain, Earn Auto Reviewer.
- Gitignores `.claude/worktrees/` (agent worktree scratch, regenerated per session) so it stops surfacing as untracked noise.

## Why

Surfaces dormant content into the file-based `content/work` pipeline, and clears post-Rails-migration leftovers so `git status` stays clean.

## Notes

- **All entries are `status: Draft`** → excluded from the `/work` listing and 404 on the show page (per `loadWorks`) until reviewed and flipped. Nothing goes live on merge.
- Build verified locally: `npm ci` + `next build` is green — all 7 parse through gray-matter/Zod, and `/work/[slug]` still generates only the 5 published pages.
- **KoperasiChain was deliberately excluded** — its draft claimed Garuda Spark 2nd place, but `data/achievements.yml` credits that win to OpenBudget.ID. Kept out pending review rather than published with an unsupported claim.

## To publish a draft later

Flip `status: Draft` to a real status, set accurate `created_at` (+ optional `started_at`/`launched_at`), and give the body a final read.