### PR TITLE
fix: widen hackathon radar table beyond the prose column

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1308,6 +1308,11 @@ textarea:focus-visible,
 
 /* ---- Hackathon Radar (journal embed) ---- */
 .radar { margin: 2rem 0; font-size: 0.85rem; }
+/* On wider screens, let the data table break out of the narrow prose column. */
+@media (min-width: 48rem) {
+  .radar { position: relative; left: 50%; transform: translateX(-50%); width: min(94vw, 1140px); }
+}
+.radar-scroll { overflow-x: auto; }
 .radar-stats { display: flex; gap: 0.75rem; flex-wrap: wrap; margin-bottom: 0.75rem; }
 .radar-stat { background: #fffdf6; border: 1px solid rgba(59,44,34,.14); border-radius: 10px; padding: 0.5rem 0.85rem; }
 .radar-stat b { display: block; font-size: 1.1rem; }
@@ -1316,7 +1321,7 @@ textarea:focus-visible,
 .radar-controls input[type="text"], .radar-controls select { font: inherit; font-size: 0.8rem; padding: 0.4rem 0.6rem; border: 1px solid rgba(59,44,34,.18); border-radius: 7px; background: var(--color-cream, #FFF7E1); color: var(--color-brown, #3B2C22); }
 .radar-search { flex: 1; min-width: 180px; }
 .radar-checkbox { font-size: 0.75rem; opacity: .8; display: inline-flex; gap: 0.3rem; align-items: center; }
-.radar-table { width: 100%; border-collapse: collapse; }
+.radar-table { width: 100%; border-collapse: collapse; min-width: 680px; }
 .radar-table th { text-align: left; border-bottom: 1px solid rgba(59,44,34,.18); padding: 0.4rem 0.5rem; }
 .radar-table th button { font: inherit; font-size: 0.62rem; text-transform: uppercase; letter-spacing: .5px; background: none; border: none; cursor: pointer; color: var(--color-brown, #3B2C22); opacity: .7; padding: 0; }
 .radar-table th button:hover { opacity: 1; }
@@ -1329,7 +1334,8 @@ textarea:focus-visible,
 .radar-toggle:hover { color: var(--color-link, #0D7390); }
 .radar-arrow { font-size: 0.6rem; opacity: .5; }
 .radar-ext { margin-left: 0.4rem; color: var(--color-link, #0D7390); text-decoration: none; }
-.radar-prize { font-weight: 700; }
+.radar-prize { font-weight: 700; white-space: nowrap; }
+.radar-deadline { white-space: nowrap; }
 .radar-fit, .radar-loc { display: inline-block; padding: 1px 7px; border-radius: 20px; font-size: 0.72rem; white-space: nowrap; }
 .loc-remote { background: rgba(60,106,18,.13); color: var(--color-green-deep, #3C6A12); }
 .loc-hybrid { background: rgba(249,200,70,.24); color: #8a6a10; }

--- a/src/components/islands/HackathonRadar.tsx
+++ b/src/components/islands/HackathonRadar.tsx
@@ -126,6 +126,7 @@ export function HackathonRadar({ hackathons, asOf, source }: HackathonRadarProps
         </label>
       </div>
 
+      <div className="radar-scroll">
       <table className="radar-table">
         <thead>
           <tr>
@@ -168,7 +169,7 @@ export function HackathonRadar({ hackathons, asOf, source }: HackathonRadarProps
                   </td>
                   <td><span className={"radar-fit fit-" + hk.fit}>{FIT_LABEL[hk.fit]}</span></td>
                   <td className="radar-prize">{hk.prize}</td>
-                  <td>{hk.deadlineWIB}</td>
+                  <td className="radar-deadline">{hk.deadlineWIB}</td>
                   <td><span className={"radar-loc " + loc.cls}>{loc.icon} {hk.location}</span></td>
                   <td className="radar-theme">{hk.theme}</td>
                 </tr>
@@ -198,6 +199,7 @@ export function HackathonRadar({ hackathons, asOf, source }: HackathonRadarProps
           })}
         </tbody>
       </table>
+      </div>
 
       {visible.length === 0 && <p className="radar-empty">No hackathons match your filters.</p>}
 


### PR DESCRIPTION
## Summary

The live radar table was cramped into the journal post's `max-w-2xl` reading column — 6 columns in ~624px forced hackathon names to wrap to 3 lines, deadlines/prizes to 2, and wasted the horizontal space on wide screens.

This lets the **data table break out wider than the prose** (the prose stays at the readable column width):
- `.radar` breaks out to `min(94vw, 1140px)`, centered, on `>=48rem` viewports
- table wrapped in `.radar-scroll` (`overflow-x:auto`) + `min-width:680px` so it scrolls inside its own box on phones (no page-level horizontal scroll)
- `prize` + `deadline` cells set `white-space:nowrap`

Verified locally at 1600px (names now single-line, no wasted space) — see the before/after in the chat.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run test` — 613/613 (wrapper div didn't break any island/page selectors)
- [x] `npm run build` succeeds (post still SSGs)