### PR TITLE
fix: count full git history for the version footer on Vercel

### DIFF
--- a/scripts/gen-version.mjs
+++ b/scripts/gen-version.mjs
@@ -9,7 +9,9 @@
 // Data sources (per the locked decisions):
 //   - sha    : VERCEL_GIT_COMMIT_SHA, else `git rev-parse HEAD`
 //   - branch : VERCEL_GIT_COMMIT_REF, else `git rev-parse --abbrev-ref HEAD`
-//   - count  : `git rev-list --count HEAD`
+//   - count  : `git rev-list --count HEAD`, AFTER deepening a shallow checkout
+//              (Vercel clones with `--depth=10`, which would otherwise undercount
+//              — e.g. 21 instead of the true total when HEAD is a merge commit)
 //   - time   : current ISO timestamp (the build time)
 //
 // NULL-SAFE: any git failure (no repo / git missing / shallow checkout without
@@ -45,6 +47,20 @@ function clean(value) {
 const sha = clean(process.env.VERCEL_GIT_COMMIT_SHA) ?? git(["rev-parse", "HEAD"]);
 const branch =
   clean(process.env.VERCEL_GIT_COMMIT_REF) ?? git(["rev-parse", "--abbrev-ref", "HEAD"]);
+
+// Vercel checks out a SHALLOW clone (`git clone --depth=10`), so a plain
+// `git rev-list --count HEAD` would count only the ~10 most recent history
+// layers (21 here, since HEAD is a 2-parent merge commit) instead of the true
+// total. Deepen to full history first. RECTOR-LABS/core is PUBLIC, so this needs
+// no credentials. It is best-effort + null-safe: if the fetch fails (offline /
+// no usable remote) we fall back to counting whatever history is present — the
+// same behavior as before this guard — so the build never breaks. The
+// `--is-shallow-repository` guard means non-shallow checkouts (local builds)
+// skip the network call entirely, and `--unshallow` is never run on a complete
+// repo (which would error).
+if (git(["rev-parse", "--is-shallow-repository"]) === "true") {
+  git(["fetch", "--unshallow", "--quiet"]);
+}
 
 const countRaw = git(["rev-list", "--count", "HEAD"]);
 const parsedCount = countRaw === null ? NaN : Number.parseInt(countRaw, 10);


### PR DESCRIPTION
## What

The deploy version pill (bottom-right footer, production only) showed **21 Commits** instead of the true **310**.

## Why

Vercel builds from a **shallow clone** (`git clone --depth=10`). The count is stamped at build time by `scripts/gen-version.mjs` running `git rev-list --count HEAD`, which can only count commits present in the shallow checkout. Because `HEAD` is a 2-parent merge commit, depth-10 surfaces ~21 commits. (The SHA stayed correct because it falls back to `VERCEL_GIT_COMMIT_SHA`; the count had no such fallback.)

## Fix

Deepen the checkout with `git fetch --unshallow` before counting, guarded by `git rev-parse --is-shallow-repository` so it only runs when needed.

- **Public repo** → no credentials required.
- **Best-effort + null-safe** → a failed fetch silently falls back to the prior behavior; the build never breaks.
- **Local builds** (non-shallow) skip the network call entirely.

## Verification

| Scenario | Before | After |
|---|---|---|
| Local (non-shallow) build | 310 | 310 (no network call) |
| Simulated Vercel depth=10 (branch) | 21 | **310** |
| Simulated Vercel depth=10 (**detached HEAD**) | 21 | **310** |
| `vitest run version` | — | 50/50 pass |

Note: the live footer updates to 310 only after this lands on `main` and Vercel runs a fresh production build (the count is baked at build time).