### PR TITLE
feat: auto-discover GitHub orgs for the homepage showcase

### DIFF
--- a/src/lib/github/repos.test.ts
+++ b/src/lib/github/repos.test.ts
@@ -1,11 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   fetchRepos,
+  discoverAccounts,
   latest,
   aggregateStats,
   recentlyActive,
   currentlyBuilding,
   DEFAULT_ACCOUNTS,
+  PRIMARY_ACCOUNT,
+  EXCLUDED_ACCOUNTS,
   type Repo,
 } from "./repos";
 
@@ -98,10 +101,185 @@ afterEach(() => {
 // DEFAULT_ACCOUNTS
 // ---------------------------------------------------------------------------
 
-describe("DEFAULT_ACCOUNTS", () => {
-  it("includes rz1989s and RECTOR-LABS", () => {
+describe("account constants", () => {
+  it("DEFAULT_ACCOUNTS (the discovery fallback) includes the flagship accounts", () => {
     expect(DEFAULT_ACCOUNTS).toContain("rz1989s");
     expect(DEFAULT_ACCOUNTS).toContain("RECTOR-LABS");
+    expect(DEFAULT_ACCOUNTS).toContain("sip-protocol");
+  });
+
+  it("PRIMARY_ACCOUNT is the personal login", () => {
+    expect(PRIMARY_ACCOUNT).toBe("rz1989s");
+  });
+
+  it("EXCLUDED_ACCOUNTS denies the NDA-bound org (compliance)", () => {
+    expect(EXCLUDED_ACCOUNTS).toContain("VOT-Labs");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// discoverAccounts — dynamic org detection + compliance denylist
+// ---------------------------------------------------------------------------
+
+/** Build a minimal Response-like object for an orgs payload. */
+function orgsResponse(logins: string[]) {
+  return {
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(logins.map((login) => ({ login }))),
+    headers: new Headers(),
+  };
+}
+
+describe("discoverAccounts", () => {
+  it("returns PRIMARY_ACCOUNT first, then its public orgs", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(orgsResponse(["RECTOR-LABS", "sip-protocol", "getlumos"]));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const accounts = await discoverAccounts();
+
+    expect(accounts[0]).toBe("rz1989s");
+    expect(accounts).toEqual(["rz1989s", "RECTOR-LABS", "sip-protocol", "getlumos"]);
+    // It hit the public-orgs endpoint of the primary account.
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toContain("/users/rz1989s/orgs");
+  });
+
+  it("excludes denylisted orgs case-insensitively", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(orgsResponse(["RECTOR-LABS", "VOT-Labs", "vot-labs", "VOT-LABS"]));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const accounts = await discoverAccounts();
+
+    expect(accounts).toEqual(["rz1989s", "RECTOR-LABS"]);
+    expect(accounts.some((a) => a.toLowerCase() === "vot-labs")).toBe(false);
+  });
+
+  it("dedupes and ignores blank/missing logins", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve([{ login: "RECTOR-LABS" }, { login: "RECTOR-LABS" }, { login: "" }, {}, { login: "rz1989s" }]),
+      headers: new Headers(),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const accounts = await discoverAccounts();
+
+    // rz1989s appears once (it is prepended; the org-list duplicate collapses), RECTOR-LABS once.
+    expect(accounts).toEqual(["rz1989s", "RECTOR-LABS"]);
+  });
+
+  it("falls back to DEFAULT_ACCOUNTS on a non-2xx orgs response", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      json: () => Promise.resolve({ message: "Forbidden" }),
+      headers: new Headers(),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const accounts = await discoverAccounts();
+
+    expect(accounts).toEqual([...DEFAULT_ACCOUNTS]);
+    expect(consoleSpy).toHaveBeenCalled();
+    expect(consoleSpy.mock.calls[0][0] as string).toMatch(/403/);
+  });
+
+  it("falls back to DEFAULT_ACCOUNTS on a network error", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const fetchMock = vi.fn().mockRejectedValueOnce(new TypeError("fetch failed"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const accounts = await discoverAccounts();
+
+    expect(accounts).toEqual([...DEFAULT_ACCOUNTS]);
+    expect(consoleSpy).toHaveBeenCalled();
+  });
+
+  it("falls back to DEFAULT_ACCOUNTS on a malformed (non-array) payload", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ message: "not an array" }),
+      headers: new Headers(),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const accounts = await discoverAccounts();
+
+    expect(accounts).toEqual([...DEFAULT_ACCOUNTS]);
+    expect(consoleSpy).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchRepos — auto-discovery when no explicit accounts are passed
+// ---------------------------------------------------------------------------
+
+describe("fetchRepos — auto-discovery", () => {
+  it("with no args, discovers orgs then fetches repos for each discovered account", async () => {
+    const fetchMock = vi.fn((url: string) => {
+      if (url.includes("/users/rz1989s/orgs")) {
+        return Promise.resolve(orgsResponse(["sip-protocol"]));
+      }
+      // Any repos-list endpoint → empty page (no commit-info calls needed).
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve([]),
+        headers: new Headers(),
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const repos = await fetchRepos();
+
+    expect(repos).toEqual([]);
+    const urls = (fetchMock.mock.calls as [string][]).map(([u]) => u);
+    expect(urls.some((u) => u.includes("/users/rz1989s/orgs"))).toBe(true);
+    expect(urls.some((u) => u.includes("/users/rz1989s/repos"))).toBe(true);
+    expect(urls.some((u) => u.includes("/users/sip-protocol/repos"))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchRepos — .github profile-repo exclusion
+// ---------------------------------------------------------------------------
+
+describe("fetchRepos — excludes .github profile repos", () => {
+  it("drops the .github repo and never fetches commit info for it", async () => {
+    const dotGithub = makeGithubRepo({ name: ".github", full_name: "sip-protocol/.github" });
+    const realRepo = makeGithubRepo({ name: "sip-protocol", full_name: "sip-protocol/sip-protocol" });
+
+    const fetchMock = vi.fn();
+    // Repos page contains BOTH the profile repo and a real project.
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve([dotGithub, realRepo]),
+      headers: new Headers(),
+    });
+    // Commit info — only the real repo should ask for it.
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve([{ sha: "abcdef1234" }]),
+      headers: new Headers(),
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const repos = await fetchRepos(["sip-protocol"]);
+
+    expect(repos).toHaveLength(1);
+    expect(repos[0].name).toBe("sip-protocol");
+
+    const urls = (fetchMock.mock.calls as [string][]).map(([u]) => u);
+    expect(urls.some((u) => u.includes("/repos/sip-protocol/.github/commits"))).toBe(false);
+    expect(urls.some((u) => u.includes("/repos/sip-protocol/sip-protocol/commits"))).toBe(true);
   });
 });
 

--- a/src/lib/github/repos.ts
+++ b/src/lib/github/repos.ts
@@ -51,8 +51,31 @@ export interface Repo {
 // Constants
 // ---------------------------------------------------------------------------
 
-/** Default accounts to fetch — port of GithubApiService::PERSONAL_ACCOUNT + RECTOR-LABS org */
-export const DEFAULT_ACCOUNTS = ["rz1989s", "RECTOR-LABS"] as const;
+/**
+ * The site owner's personal GitHub login. Always shown first, and the account
+ * whose public org memberships are auto-discovered (see {@link discoverAccounts}).
+ */
+export const PRIMARY_ACCOUNT = "rz1989s";
+
+/**
+ * Compliance denylist for account auto-discovery (matched case-insensitively).
+ *
+ * {@link discoverAccounts} pulls EVERY public org the PRIMARY_ACCOUNT belongs to,
+ * so this is the inverse of the old hardcoded allowlist: new orgs surface
+ * automatically, but any org listed here can never leak onto the public site.
+ *
+ * `VOT-Labs` — the Intric / Arbital ecosystem, bound by a 3-year NDA. Excluded
+ * unconditionally as defense-in-depth: its membership is private today, but if
+ * that ever flips to public it still must never appear here.
+ */
+export const EXCLUDED_ACCOUNTS = ["VOT-Labs"] as const;
+
+/**
+ * Static fallback account list, used ONLY when org auto-discovery fails (orgs
+ * endpoint non-2xx / network error / malformed payload). Keeps the homepage
+ * populated with the flagship accounts in a degraded state.
+ */
+export const DEFAULT_ACCOUNTS = ["rz1989s", "RECTOR-LABS", "sip-protocol"] as const;
 
 const API_BASE = "https://api.github.com";
 
@@ -143,6 +166,63 @@ async function fetchCommitInfo(
 }
 
 // ---------------------------------------------------------------------------
+// Account discovery
+// ---------------------------------------------------------------------------
+
+/**
+ * Discover the accounts to showcase: the PRIMARY_ACCOUNT plus every PUBLIC org
+ * it belongs to (`GET /users/{login}/orgs`), minus the EXCLUDED_ACCOUNTS
+ * compliance denylist. This replaces the old hardcoded allowlist so newly
+ * created/joined orgs (e.g. sip-protocol) appear automatically.
+ *
+ * Graceful degradation: any failure (non-2xx, network error, malformed payload)
+ * is logged with actionable context and falls back to DEFAULT_ACCOUNTS — it
+ * never throws, so the homepage always renders.
+ *
+ * Note: the public-orgs endpoint returns only PUBLIC memberships, which is also
+ * why a private-membership org (like the denylisted one) does not appear here in
+ * the first place; the denylist is the explicit, membership-independent guard.
+ */
+export async function discoverAccounts(): Promise<string[]> {
+  const headers = buildHeaders();
+  const url = `${API_BASE}/users/${PRIMARY_ACCOUNT}/orgs?per_page=100`;
+
+  try {
+    const res = await githubFetch(url, headers);
+
+    if (!res.ok) {
+      console.error(
+        `GitHub API error discovering orgs for "${PRIMARY_ACCOUNT}": HTTP ${res.status} — ${url}. Falling back to DEFAULT_ACCOUNTS.`,
+      );
+      return [...DEFAULT_ACCOUNTS];
+    }
+
+    const orgs = (await res.json()) as Array<{ login?: string }>;
+    if (!Array.isArray(orgs)) {
+      console.error(
+        `GitHub API returned a non-array orgs payload for "${PRIMARY_ACCOUNT}" — falling back to DEFAULT_ACCOUNTS.`,
+      );
+      return [...DEFAULT_ACCOUNTS];
+    }
+
+    const excluded = new Set(EXCLUDED_ACCOUNTS.map((a) => a.toLowerCase()));
+    const orgLogins = orgs
+      .map((o) => o.login)
+      .filter((login): login is string => typeof login === "string" && login.length > 0)
+      .filter((login) => !excluded.has(login.toLowerCase()));
+
+    // PRIMARY_ACCOUNT first, then discovered orgs; dedupe defensively (a Set also
+    // collapses any accidental duplicate org logins from the API).
+    return Array.from(new Set([PRIMARY_ACCOUNT, ...orgLogins]));
+  } catch (err) {
+    console.error(
+      `GitHub API exception discovering orgs for "${PRIMARY_ACCOUNT}": ${String(err)} — falling back to DEFAULT_ACCOUNTS.`,
+    );
+    return [...DEFAULT_ACCOUNTS];
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Main fetcher
 // ---------------------------------------------------------------------------
 
@@ -164,15 +244,19 @@ async function fetchCommitInfo(
  * account is logged via console.error with actionable context and skipped;
  * other accounts continue unaffected.
  *
- * @param accounts - GitHub user/org login names to fetch (default: DEFAULT_ACCOUNTS)
+ * @param accounts - Explicit GitHub user/org logins to fetch. Omit to
+ *   auto-discover via {@link discoverAccounts} (PRIMARY_ACCOUNT + its public
+ *   orgs, minus EXCLUDED_ACCOUNTS). An explicit `[]` fetches nothing.
  */
-export async function fetchRepos(
-  accounts: string[] = [...DEFAULT_ACCOUNTS],
-): Promise<Repo[]> {
+export async function fetchRepos(accounts?: string[]): Promise<Repo[]> {
+  // No explicit list → auto-discover. An explicit array (including []) is
+  // honored verbatim, which keeps unit tests deterministic and lets callers
+  // scope the fetch to specific accounts.
+  const resolvedAccounts = accounts ?? (await discoverAccounts());
   const headers = buildHeaders();
   const allRepos: Repo[] = [];
 
-  for (const account of accounts) {
+  for (const account of resolvedAccounts) {
     try {
       const accountRepos = await fetchAccountRepos(account, headers);
       allRepos.push(...accountRepos);
@@ -254,9 +338,16 @@ async function fetchAccountRepos(
       topics?: string[];
     }>;
 
+    // Drop org/user PROFILE repos (".github") before doing anything else: they
+    // hold community-health files / the profile README, not a project, so they
+    // would render as empty cards and inflate the repo + tech-stack counts once
+    // orgs are auto-included. Skipping them here also avoids a wasted commit-info
+    // request per profile repo.
+    const projectRepos = raw.filter((r) => r.name !== ".github");
+
     // Resolve commit info for each repo on this page (faithful to Rails parse_repos)
     const pageRepos = await Promise.all(
-      raw.map(async (r) => {
+      projectRepos.map(async (r) => {
         const commitInfo = await fetchCommitInfo(r.full_name, headers);
         return {
           fullName: r.full_name,


### PR DESCRIPTION
## Problem

The homepage "Building in Public" section (and the repo count, tech-stack tallies, "recently shipping", and "currently building") only listed repos owned by a **hardcoded allowlist of two accounts** (`repos.ts`: `["rz1989s", "RECTOR-LABS"]`).

Repos owned by other orgs — `sip-protocol`, `getlumos`, `nanuqfi`, ... — were **never fetched**, so they never appeared, even while the contribution graph (GraphQL, all-activity) already reflected that work. (`sip-protocol` was pushed *today*, yet was invisible.)

## Fix

Replace the static allowlist with **dynamic discovery**:

- `discoverAccounts()` lists the primary account's **public orgs** (`GET /users/rz1989s/orgs`) and prepends the account itself → new orgs surface automatically, no code edit needed.
- A **compliance denylist** (`EXCLUDED_ACCOUNTS`) guarantees the NDA-bound org can never appear — the inverse of the old allowlist (defense-in-depth, independent of membership visibility).
- Discovery **degrades to a static fallback** (`DEFAULT_ACCOUNTS`) on any non-2xx / network error / malformed payload, so the homepage always renders.
- `.github` profile repos are dropped so org additions don't render empty cards or inflate the counts.

`fetchRepos()` now auto-discovers when called with no args (both `/` and `/work` use it); an explicit account array (incl. `[]`) is still honored for tests/scoped fetches.

## Verification

Against live data:
- Discovery returns all 8 public accounts; **`VOT-Labs` excluded** ✓
- Top-6 now surfaces 4 `sip-protocol` repos alongside `core`/`conatus`; `sip-protocol` in top-6: **true**
- Repo count grows ~47 → ~70 (expected — more orgs counted)

Tests: **104** github tests pass (added `discoverAccounts`, denylist, `.github`-filter, and auto-discovery coverage); full suite **623** pass; `tsc` + lint clean.

## Notes

- More repos = a few more GitHub API calls per hourly ISR rebuild (~80/page). Well within the authenticated 5,000/hr in production.
- Recency-ranking means an active org (sip-protocol today) can dominate the top-6. Faithful to the existing "most recently pushed" design; per-account diversity would be a separate change if wanted.