### PR TITLE
fix: correct and NDA-sanitize resume/CV data

### DIFF
--- a/data/achievements.yml
+++ b/data/achievements.yml
@@ -29,17 +29,17 @@
   description: Autonomous 4-layer signal fusion engine detecting Solana narratives daily. Z-score anomaly detection, LLM clustering, and build idea generation from onchain, developer, social, and market signals.
 
 - slug: adrena-trading-arena
-  title: Adrena Trading Arena
+  title: Adrena AI Agent Arena
   type: bounty
   place: 2nd
   prize_amount: 1500
   prize_extras: null
-  event: Adrena x Autonom Trading Competition
+  event: Adrena x Autonom Competition
   event_detail: Superteam Earn
   date: "2026-04"
-  github_url: https://github.com/RECTOR-LABS/adrena-trading-arena
-  repo_name: adrena-trading-arena
-  description: On-chain trading competition platform for Adrena Protocol. 4-layer monorepo with Anchor program, TypeScript SDK, Rust orchestrator, and Next.js frontend.
+  github_url: https://github.com/RECTOR-LABS/adrena-agent-arena
+  repo_name: adrena-agent-arena
+  description: Autonomous on-chain AI agent competition platform for Adrena Protocol. 4-layer monorepo with Anchor program, TypeScript SDK, Rust orchestrator, and Next.js frontend.
 
 - slug: sip-protocol-graveyard-torque
   title: SIP Protocol

--- a/data/resume.yml
+++ b/data/resume.yml
@@ -17,27 +17,28 @@ personal:
 
 stats:
   - label: Vulnerabilities Found
-    value: "125"
-    number: 125
+    value: "13"
+    number: 13
   - label: Repositories
     value: "64+"
     number: 64
 
 summary:
   pdf: >-
-    Full-stack Solana engineer with 10 wins across hackathons, bounties, and
-    grants totaling $34.5K+ in the Solana ecosystem. Awarded $10K Solana
-    Foundation grant and $6K audit subsidy for SIP Protocol. Currently
-    building multi-chain automated trading infrastructure in Rust (Axum,
-    Tokio, TimescaleDB) across Solana, Starknet, and ZKSync.
-    Security-focused: conducted Solana gaming protocol audit documenting
-    125 vulnerabilities. Built LUMOS, a type-safe schema language bridging
-    Rust and TypeScript for Solana with full IDE ecosystem.
+    Full-stack Solana engineer with 11 wins across hackathons, bounties, and
+    grants totaling $36K+ in the Solana ecosystem, including a $10K Solana
+    Foundation grant and $6K audit subsidy for SIP Protocol. Placed 1st of
+    116 in a Solana security audit competition — reviewed 14 open-source
+    protocols and reported 13 findings, the top one a framework-level Anchor
+    CPI vulnerability (CVSS 7.5), fixed upstream. Builds production AI agents
+    and the MCP tooling they run on, in Rust and TypeScript. Also built
+    LUMOS, a type-safe schema language bridging Rust and TypeScript for Solana.
   web: >-
-    Full-stack Solana engineer. 10 wins, $34.5K+ earned, $16K in grants.
-    Building production trading infrastructure in Rust across
-    Solana/Starknet/ZKSync. Security-focused: 125 vulnerabilities
-    documented in Solana gaming protocol audit.
+    Full-stack Solana engineer. 11 wins, $36K+ earned, $16K in grants.
+    Placed 1st of 116 in a Solana security audit — 13 findings across 14
+    protocols, the top a framework-level Anchor CPI vulnerability (CVSS 7.5)
+    fixed upstream. Builds production AI agents and MCP tooling in Rust and
+    TypeScript.
 
 skills:
   - category: Languages
@@ -55,15 +56,15 @@ skills:
 
 experience:
   - title: Full Stack Developer & Agentic Engineer
-    company: Intric LLC (arbital.xyz)
+    company: Confidential DeFi Startup
     date_start: "2026-02"
-    date_end: present
+    date_end: "2026-06"
     location: "Remote — Jakarta, Indonesia"
     bullets:
-      - text: "Building Arbital, a multi-tenant automated trading bot platform for decentralized exchanges, written in Rust (Axum, Tokio async runtime)"
+      - text: "Built backend services in Rust (Axum, Tokio async runtime) for a multi-tenant DeFi platform"
         pdf: true
         web: true
-      - text: "Designed AES-256-GCM encrypted credential storage with random nonces for secure exchange API key management"
+      - text: "Designed AES-256-GCM encrypted credential storage with random nonces for secure API key management"
         pdf: true
         web: true
       - text: "Built EIP-712 wallet-based authentication with challenge-response flow, JWT sessions, and stratified rate limiting (5 tiers)"
@@ -72,7 +73,7 @@ experience:
       - text: "Implemented multi-chain cryptographic signing: Ed25519 (Solana), Stark key (Starknet), EIP-712 (ZKSync)"
         pdf: true
         web: true
-      - text: "Designed distributed bot execution with Redis-based locking (120s TTL, 60s heartbeat), state snapshots, and graceful shutdown"
+      - text: "Designed distributed job execution with Redis-based locking (120s TTL, 60s heartbeat), state snapshots, and graceful shutdown"
         pdf: false
         web: true
       - text: "Built event-driven persistence pipeline: Redis Streams to TimescaleDB via dedicated DB writer service"
@@ -81,7 +82,7 @@ experience:
       - text: "Managed secret infrastructure with SOPS + age encryption for staging/production environments"
         pdf: false
         web: true
-      - text: "Implemented proxy clustering for exchange rate limit compliance across concurrent bot instances"
+      - text: "Implemented proxy clustering for upstream rate-limit compliance across concurrent worker instances"
         pdf: false
         web: true
 
@@ -143,10 +144,10 @@ projects:
     description: Type-safe schema language bridging Rust and TypeScript for Solana. Full IDE ecosystem.
     tags: [Rust, TypeScript, LSP, Tree-sitter]
     featured: true
-  - name: Adrena Trading Arena
+  - name: Adrena AI Agent Arena
     org: RECTOR-LABS
-    github_url: https://github.com/RECTOR-LABS/adrena-trading-arena
-    description: On-chain trading competition platform for Adrena Protocol with Anchor program, SDK, Rust orchestrator, and Next.js frontend.
+    github_url: https://github.com/RECTOR-LABS/adrena-agent-arena
+    description: Autonomous on-chain AI agent competition platform for Adrena Protocol with Anchor program, SDK, Rust orchestrator, and Next.js frontend.
     tags: [Solana, Anchor, Rust, TypeScript, Next.js]
     featured: true
   - name: OpenBudget.ID

--- a/scripts/generate-resume-pdf.mjs
+++ b/scripts/generate-resume-pdf.mjs
@@ -127,7 +127,7 @@ function buildPdfStats(achievements) {
   return {
     wins:         String(winCount),
     earnings:     `$${totalEarnings.toLocaleString("en-US")}+`,
-    vulns:        "125",                                          // hardcoded in ERB
+    vulns:        "13",                                           // Superteam audit: 13 findings (corrected from stale "125" gaming-audit claim)
     grantsAmount: `$${grantsTotal.toLocaleString("en-US")}`,
   };
 }

--- a/src/lib/content/resume.test.ts
+++ b/src/lib/content/resume.test.ts
@@ -61,8 +61,8 @@ describe("loadResume", () => {
         expect(typeof bullet.text).toBe("string");
       }
     }
-    // First entry is the Intric role
-    expect(experience[0].company).toBe("Intric LLC (arbital.xyz)");
+    // First entry is the (NDA-anonymized) most-recent role
+    expect(experience[0].company).toBe("Confidential DeFi Startup");
   });
 
   it("projects is a non-empty array with the expected fields", () => {

--- a/src/lib/content/superteam.test.ts
+++ b/src/lib/content/superteam.test.ts
@@ -62,11 +62,11 @@ describe("buildStats", () => {
     const result = buildStats({ totalEarnings, winCount, achievements: all }, stats);
 
     // Mirrors prod (curl https://rectorspace.com/apply/superteam):
-    //   $36,050+ / 11 / 125 / 64+ / 2
+    //   $36,050+ / 11 / 13 / 64+ / 2
     expect(result).toEqual([
       { label: "Ecosystem Earnings", value: `$${totalEarnings.toLocaleString("en-US")}+`, number: totalEarnings },
       { label: "Wins", value: String(winCount), number: winCount },
-      { label: "Vulnerabilities Found", value: "125", number: 125 },
+      { label: "Vulnerabilities Found", value: "13", number: 13 },
       { label: "Repositories", value: "64+", number: 64 },
       { label: "Grants Received", value: String(grants), number: grants },
     ]);
@@ -74,7 +74,7 @@ describe("buildStats", () => {
 
   it("places earnings first and grants last, with YAML stats in between in order", () => {
     const yamlStats = [
-      { label: "Vulnerabilities Found", value: "125", number: 125 },
+      { label: "Vulnerabilities Found", value: "13", number: 13 },
       { label: "Repositories", value: "64+", number: 64 },
     ];
     const achievements = [
@@ -92,7 +92,7 @@ describe("buildStats", () => {
     expect(result).toEqual([
       { label: "Ecosystem Earnings", value: "$23,000+", number: 23000 },
       { label: "Wins", value: "4", number: 4 },
-      { label: "Vulnerabilities Found", value: "125", number: 125 },
+      { label: "Vulnerabilities Found", value: "13", number: 13 },
       { label: "Repositories", value: "64+", number: 64 },
       { label: "Grants Received", value: "2", number: 2 },
     ]);
@@ -172,7 +172,7 @@ describe("sortAwardsByPrize", () => {
   it("is a stable sort for equal prize amounts (preserves YAML order)", () => {
     // Ruby's sort_by is stable; ties keep their original relative order.
     const a = makeAchievement({ prizeAmount: 1500, slug: "a", title: "Solana Security Audit" });
-    const b = makeAchievement({ prizeAmount: 1500, slug: "b", title: "Adrena Trading Arena" });
+    const b = makeAchievement({ prizeAmount: 1500, slug: "b", title: "Adrena AI Agent Arena" });
     const c = makeAchievement({ prizeAmount: 1500, slug: "c", title: "OpenBudget.ID" });
     const sorted = sortAwardsByPrize([a, b, c]);
     expect(sorted.map((x) => x.slug)).toEqual(["a", "b", "c"]);
@@ -236,7 +236,7 @@ describe("featuredProjects", () => {
       "Web3 Deal Discovery",
       "pNode Pulse",
       "LUMOS",
-      "Adrena Trading Arena",
+      "Adrena AI Agent Arena",
     ]);
     expect(featured.every((p) => p.featured === true)).toBe(true);
   });


### PR DESCRIPTION
## What

Corrects and NDA-sanitizes the CV data that feeds both the resume PDF and the live `/apply/superteam` page.

## Why

The live `/apply/superteam` page (and the generated PDF) carried three problems:

1. **NDA exposure** — a recent experience entry named the confidential employer and described its proprietary multi-tenant platform architecture, in a CV sent to security firms.
2. **A disproven security claim** — a "125 vulnerabilities / gaming protocol audit" line carried verbatim from the old Rails ERB and never corrected.
3. **Stale totals** — "10 wins / $34.5K" contradicting the auto-calculated "11 wins / $36,050".

## Changes

- `data/resume.yml` — rewrote `summary.pdf` / `summary.web` to accurate framing (11 wins / $36,050, 1st of 116, 13 findings, Anchor CPI CVSS-7.5, AI-agents/MCP); stat "Vulnerabilities Found" `125 → 13`; anonymized the recent entry → "Confidential DeFi Startup" with closed dates and confidential specifics stripped (transferable Rust/Axum/Tokio + AES-256-GCM + EIP-712 retained); de-branded the Adrena project entry.
- `data/achievements.yml` — Adrena award title/event/description de-scoped; repo URL updated.
- `scripts/generate-resume-pdf.mjs` — hardcoded `vulns "125" → "13"`.
- `src/lib/content/{resume,superteam}.test.ts` — assertions updated to match.

## Verification

- `npm run test` — 629/629 passing.
- Code-traced: `/apply/superteam` renders only `resume.yml` + `achievements.yml` (both corrected here), so this fully clears that page's exposure.
