### PR TITLE
feat(apply): add head-of-engineering CV (shadcn/ui)

### DIFF
--- a/components.json
+++ b/components.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "src/app/globals.css",
+    "baseColor": "zinc",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "iconLibrary": "lucide"
+}

--- a/data/resume.yml
+++ b/data/resume.yml
@@ -55,12 +55,20 @@ skills:
     items: [Solana (Anchor/SPL), Starknet, ZKSync, NEAR Protocol, Zcash]
 
 experience:
-  - title: Full Stack Developer & Agentic Engineer
-    company: Confidential DeFi Startup
+  - title: Tech Lead, Agentic Terminal
+    company: Arbital.xyz
     date_start: "2026-02"
     date_end: "2026-06"
     location: "Remote — Jakarta, Indonesia"
     bullets:
+      # ⚠️ RECTOR: confirm/edit specifics before this ships (team size led,
+      # what the Agentic Terminal actually does, scale/throughput, exact stack).
+      - text: "Promoted from Full Stack Developer to Tech Lead; led the Agentic Terminal product line end-to-end"
+        pdf: true
+        web: true
+      - text: "Architected and built the Arbital Agentic Terminal from scratch in Rust + TypeScript"
+        pdf: true
+        web: true
       - text: "Built backend services in Rust (Axum, Tokio async runtime) for a multi-tenant DeFi platform"
         pdf: true
         web: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,15 +8,26 @@
       "name": "web",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-accordion": "^1.2.16",
+        "@radix-ui/react-avatar": "^1.2.2",
+        "@radix-ui/react-separator": "^1.1.11",
+        "@radix-ui/react-slot": "^1.3.0",
+        "@radix-ui/react-tabs": "^1.1.17",
+        "@radix-ui/react-tooltip": "^1.2.12",
         "@vercel/analytics": "^2.0.1",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
         "gray-matter": "^4.0.3",
         "js-yaml": "^4.1.1",
+        "lucide-react": "^1.23.0",
         "next": "16.2.6",
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "react-markdown": "^10.1.0",
         "reading-time": "^1.5.0",
         "remark-gfm": "^4.0.1",
+        "tailwind-merge": "^3.6.0",
+        "tw-animate-css": "^1.4.0",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -686,6 +697,44 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
@@ -1489,6 +1538,626 @@
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.5.tgz",
+      "integrity": "sha512-d86WIWFYNtGA0H/d8exstrTRTp7eWJYlYJbtNofxr/3ljupZYn6EFDG/Qgu/0Kc8v7yMUxySagqJsL1+PdYjWg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-accordion": {
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.16.tgz",
+      "integrity": "sha512-BpZJNmetujnGgUI6OX0jEhEmlA46WPqgub8Rv09Kyquwd0cc1ndMKpiPYCjmBU6KSSRPAMtgLpEoZSG/tdNIWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-collapsible": "1.1.16",
+        "@radix-ui/react-collection": "1.1.12",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.11.tgz",
+      "integrity": "sha512-Kdil9BB1rIFC/khmf4hC35bn8701AJcizTU7G7cUbEbk5XqqbjDuHW60uUfKqO5WojjZcbAW51Q7P0hRmMLw8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.7"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-avatar": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.2.2.tgz",
+      "integrity": "sha512-sST0qh8GzOB7besQ3tMLWLyngnRuSk0gc/Hm+667KYKQFCt6Y6ZXv25WlqM7dIDK54ULCh5+CHmk4LIolzfz+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-is-hydrated": "0.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.16.tgz",
+      "integrity": "sha512-opfXRe6nnzyGmCDPx+l1Aqo/RbqWtQal2FnsBqF9hhePp6j0LsRoBaRxcMOlTv+uYTJVtWYZKg9t9wTe+BA/ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-presence": "1.1.7",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.12.tgz",
+      "integrity": "sha512-nb67INpE0IahJKN7EYPp9m9YGwYeKlnzxT3MwXVkgCskaSJia97kG4T0ywpjNUSSnoJk/uvk12V8vbrEHEj+/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-slot": "1.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.0.tgz",
+      "integrity": "sha512-fOE+JtN9rygNZkCnHRBEP0TAvLldlhyOxMsbwFvTP4nAs+nBmfnna+o/Zski2wkmY1YMrFC0aSzsHoLY47iLrg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.2.tgz",
+      "integrity": "sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.15.tgz",
+      "integrity": "sha512-b0XaRlzn2QKuo10XyNgi2DAJDf5XC9d1nD3FJcuvCjbR7+4Ad28zmZsLsqx+hvDEzMnRuZaZxZm9gYObV6RmRA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-effect-event": "0.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
+      "integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.3.tgz",
+      "integrity": "sha512-mS7dGpyjv6b+gsDjLF7e0ia1W4Im1B1hSCy2yuXlHuvnZxHKagfDaobt/KAKt27EpZMit2pss8eJBVyVjEWM+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.11",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.2",
+        "@radix-ui/react-use-rect": "1.1.2",
+        "@radix-ui/react-use-size": "1.1.2",
+        "@radix-ui/rect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.13.tgz",
+      "integrity": "sha512-z3oXfmaHLJTF1wktbjgD6cn9jiEbq3WSondB10LIuIt2m2Ym4iJlrW04/euMwENDdWDdE7z+OuY7Qyp1YpRSwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.7.tgz",
+      "integrity": "sha512-zBZ4QM5XG3JRanDmqXYf3MD6th4AFXFmgU6KNMFzUaV6F3uw9I5/zjMUvFriSEn5ewo1nxuibvyxJdmLlDcslA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.7.tgz",
+      "integrity": "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.15.tgz",
+      "integrity": "sha512-40svmmugfM3mUN7VUDGVE1tQGOhyi8enlGD0CNJEcMM36C1f71PKM21DFgNHUfem0XnA+d8H8oN3Z9ZpJjSslg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-collection": "1.1.12",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-is-hydrated": "0.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.11.tgz",
+      "integrity": "sha512-jRhe86+8PF7VZ1u14eOWVOuh2BuAhALg/FT1VcMC4OHedMTRUazDnDlKTt+yxo5cRNKHMfmvZ4sSQtWDeMV4CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.7"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
+      "integrity": "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.17.tgz",
+      "integrity": "sha512-nRyXnrAVCwjeXcHbvEbLS6ndbTeKHG1RqCP4A8Gw5L4cemDzPXdD8rAmr6wet0v57R69wGvuIIsFjHSVkZiMzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-presence": "1.1.7",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-roving-focus": "1.1.15",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.12.tgz",
+      "integrity": "sha512-U3HoftgWnmla78vzQbLvKKb7bUYJxoiiqYFzp1wu/TBMyDqMZSuCl3aRICsD6EfVEwcJD2mumGDGUXLFVqQHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-dismissable-layer": "1.1.15",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-popper": "1.3.3",
+        "@radix-ui/react-portal": "1.1.13",
+        "@radix-ui/react-presence": "1.1.7",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-slot": "1.3.0",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-visually-hidden": "1.2.7"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
+      "integrity": "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz",
+      "integrity": "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+      "integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-is-hydrated": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.1.tgz",
+      "integrity": "sha512-qwOiz4Tjo8CNnrOLAYUMXeZwDzXgXpvK4TKQPmWLECM9XoWvA6+0Z2/7Ag3A4ivjS4ovbLJPbskkxioFyBhr8A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.2.tgz",
+      "integrity": "sha512-d8a+bBY/FxikNPlgJJoaBHZX+zKVbWHYJGTLnLvveQgFSTntkGdEKv3JDtHrMS0DNYpllz2nRsTLGLKYttbpmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.2.tgz",
+      "integrity": "sha512-giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.7.tgz",
+      "integrity": "sha512-1wNZBggTDK3GRuuQ6nP4k2yi7a6l7I5qbMPbZcRsrGsGVead/f/d5FhEzUvqFs0bcrDLx7n1zKQ3JvLR6whaaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.7"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.2.tgz",
+      "integrity": "sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==",
+      "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.2",
@@ -2297,7 +2966,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
@@ -3701,11 +4370,32 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -6393,6 +7083,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.23.0.tgz",
+      "integrity": "sha512-38BpJcD0JhFosxHApP/BYsBetLpQFRoTRzEzstM/XCc3jsAG7wqaY1lgVwxiUe3xqYE+lNxo2PkCmYwXWrwwIw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -7394,6 +8093,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
       "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "16.2.6",
         "@swc/helpers": "0.5.15",
@@ -8915,6 +9615,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tailwind-merge": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+      "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
@@ -9135,6 +9845,15 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tw-animate-css": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.4.0.tgz",
+      "integrity": "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Wombosvideo"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -13,15 +13,26 @@
     "resume:pdf": "node scripts/generate-resume-pdf.mjs"
   },
   "dependencies": {
+    "@radix-ui/react-accordion": "^1.2.16",
+    "@radix-ui/react-avatar": "^1.2.2",
+    "@radix-ui/react-separator": "^1.1.11",
+    "@radix-ui/react-slot": "^1.3.0",
+    "@radix-ui/react-tabs": "^1.1.17",
+    "@radix-ui/react-tooltip": "^1.2.12",
     "@vercel/analytics": "^2.0.1",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
     "gray-matter": "^4.0.3",
     "js-yaml": "^4.1.1",
+    "lucide-react": "^1.23.0",
     "next": "16.2.6",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-markdown": "^10.1.0",
     "reading-time": "^1.5.0",
     "remark-gfm": "^4.0.1",
+    "tailwind-merge": "^3.6.0",
+    "tw-animate-css": "^1.4.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/src/app/apply/head-of-engineering/hoe.css
+++ b/src/app/apply/head-of-engineering/hoe.css
@@ -1,0 +1,161 @@
+/* ============================================================================
+   /apply/head-of-engineering — scoped "showoff" theme (shadcn/ui, dark premium)
+   ----------------------------------------------------------------------------
+   This CSS is imported ONLY by the head-of-engineering route, so its rules are
+   code-split to that route. The @theme inline block REGISTERS the shadcn color
+   utilities (bg-card, text-foreground, bg-primary, …) globally, but every value
+   resolves to a --hoe-* CSS variable that is defined ONLY under .hoe-page — so
+   the cream/brown brand tokens in src/app/globals.css are completely untouched.
+   Outside .hoe-page the shadcn utilities resolve to nothing (undefined vars),
+   which is fine because they are only ever used inside this page wrapper.
+   ========================================================================== */
+
+@import "tw-animate-css";
+
+@theme inline {
+  --color-background: var(--hoe-background);
+  --color-foreground: var(--hoe-foreground);
+  --color-card: var(--hoe-card);
+  --color-card-foreground: var(--hoe-card-foreground);
+  --color-popover: var(--hoe-popover);
+  --color-popover-foreground: var(--hoe-popover-foreground);
+  --color-primary: var(--hoe-primary);
+  --color-primary-foreground: var(--hoe-primary-foreground);
+  --color-secondary: var(--hoe-secondary);
+  --color-secondary-foreground: var(--hoe-secondary-foreground);
+  --color-muted: var(--hoe-muted);
+  --color-muted-foreground: var(--hoe-muted-foreground);
+  --color-accent: var(--hoe-accent);
+  --color-accent-foreground: var(--hoe-accent-foreground);
+  --color-destructive: var(--hoe-destructive);
+  --color-border: var(--hoe-border);
+  --color-input: var(--hoe-input);
+  --color-ring: var(--hoe-ring);
+
+  --radius-sm: calc(var(--hoe-radius) - 4px);
+  --radius-md: calc(var(--hoe-radius) - 2px);
+  --radius-lg: var(--hoe-radius);
+  --radius-xl: calc(var(--hoe-radius) + 4px);
+
+  /* Accordion expand/collapse (shadcn). Heights come from Radix at runtime. */
+  --animate-accordion-down: accordion-down 0.2s ease-out;
+  --animate-accordion-up: accordion-up 0.2s ease-out;
+
+  @keyframes accordion-down {
+    from {
+      height: 0;
+    }
+    to {
+      height: var(--radix-accordion-content-height);
+    }
+  }
+  @keyframes accordion-up {
+    from {
+      height: var(--radix-accordion-content-height);
+    }
+    to {
+      height: 0;
+    }
+  }
+}
+
+/* ── Dark premium palette, scoped to the page wrapper ───────────────────────
+   oklch for perceptually-even lightness. Primary = brand sky-cyan family. */
+.hoe-page {
+  --hoe-radius: 0.75rem;
+
+  --hoe-background: oklch(0.16 0.012 260);
+  --hoe-foreground: oklch(0.97 0.005 260);
+  --hoe-card: oklch(0.205 0.014 260);
+  --hoe-card-foreground: oklch(0.97 0.005 260);
+  --hoe-popover: oklch(0.205 0.014 260);
+  --hoe-popover-foreground: oklch(0.97 0.005 260);
+  --hoe-primary: oklch(0.78 0.15 195);
+  --hoe-primary-foreground: oklch(0.16 0.012 260);
+  --hoe-secondary: oklch(0.27 0.014 260);
+  --hoe-secondary-foreground: oklch(0.97 0.005 260);
+  --hoe-muted: oklch(0.27 0.014 260);
+  --hoe-muted-foreground: oklch(0.72 0.012 260);
+  --hoe-accent: oklch(0.3 0.016 260);
+  --hoe-accent-foreground: oklch(0.97 0.005 260);
+  --hoe-destructive: oklch(0.62 0.2 25);
+  --hoe-border: oklch(1 0 0 / 10%);
+  --hoe-input: oklch(1 0 0 / 12%);
+  --hoe-ring: oklch(0.78 0.15 195);
+
+  color-scheme: dark;
+
+  min-height: 100vh;
+  background:
+    radial-gradient(60rem 60rem at 82% -12%, oklch(0.78 0.15 195 / 0.12), transparent 60%),
+    radial-gradient(48rem 48rem at -8% 6%, oklch(0.72 0.13 285 / 0.1), transparent 55%),
+    var(--hoe-background);
+  color: var(--hoe-foreground);
+  font-family: var(--font-jetbrains, ui-monospace, SFMono-Regular, Menlo, monospace);
+}
+
+/* Subtle top "grid" texture for the hero, pure decoration. */
+.hoe-grid-bg {
+  background-image:
+    linear-gradient(to right, oklch(1 0 0 / 0.04) 1px, transparent 1px),
+    linear-gradient(to bottom, oklch(1 0 0 / 0.04) 1px, transparent 1px);
+  background-size: 44px 44px;
+  -webkit-mask-image: radial-gradient(ellipse 70% 60% at 50% 0%, #000 40%, transparent 75%);
+  mask-image: radial-gradient(ellipse 70% 60% at 50% 0%, #000 40%, transparent 75%);
+}
+
+/* Gradient text helper (hero name + accent headings). */
+.hoe-text-gradient {
+  background: linear-gradient(
+    100deg,
+    oklch(0.95 0.02 195) 0%,
+    oklch(0.82 0.15 195) 45%,
+    oklch(0.78 0.16 260) 100%
+  );
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+/* Card hover lift used across feature cards. */
+.hoe-card-hover {
+  transition: transform 220ms ease, border-color 220ms ease, box-shadow 220ms ease;
+}
+.hoe-card-hover:hover {
+  transform: translateY(-3px);
+  border-color: oklch(0.78 0.15 195 / 0.45);
+  box-shadow: 0 12px 40px oklch(0.78 0.15 195 / 0.12);
+}
+
+/* Respect reduced motion. */
+@media (prefers-reduced-motion: reduce) {
+  .hoe-card-hover {
+    transition: none;
+  }
+  .hoe-card-hover:hover {
+    transform: none;
+  }
+}
+
+/* ── Print / PDF: strip the dark chrome, force a clean light doc ──────────── */
+@media print {
+  .hoe-page {
+    --hoe-background: #fff;
+    --hoe-foreground: #111;
+    --hoe-card: #fff;
+    --hoe-card-foreground: #111;
+    --hoe-border: oklch(0 0 0 / 14%);
+    --hoe-muted-foreground: #444;
+    --hoe-primary: #0b6e8a;
+    --hoe-primary-foreground: #fff;
+    background: #fff;
+    color: #111;
+  }
+  .hoe-grid-bg,
+  .hoe-no-print {
+    display: none !important;
+  }
+  .hoe-card-hover {
+    break-inside: avoid;
+  }
+}

--- a/src/app/apply/head-of-engineering/page.tsx
+++ b/src/app/apply/head-of-engineering/page.tsx
@@ -1,0 +1,516 @@
+import { cache } from "react";
+import type { Metadata } from "next";
+import {
+  GitBranch,
+  Mail,
+  Globe,
+  MapPin,
+  ArrowUpRight,
+  ShieldCheck,
+  Code2,
+  Lock,
+  Server,
+  Database,
+  Blocks,
+  Wrench,
+  Sparkles,
+  Zap,
+  BookOpen,
+  Trophy,
+} from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { loadResume } from "@/lib/content/resume";
+import { loadAchievements } from "@/lib/content/achievements";
+import { webBullets, featuredProjects } from "@/lib/content/superteam";
+
+import { Counter } from "@/components/islands/Counter";
+import { ScrollReveal } from "@/components/islands/ScrollReveal";
+import { PrintButton } from "@/components/islands/PrintButton";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@/components/ui/avatar";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+import "./hoe.css";
+
+// Dedupe the YAML read+parse across generateMetadata and the page body within a
+// single render pass (same cache() pattern as the work + superteam routes).
+const getResume = cache(() => loadResume());
+
+// ---------------------------------------------------------------------------
+// Static SSG. All data is local YAML (resume.yml + achievements.yml) — no live
+// GitHub, no request-time fetch → no `revalidate`. Deploy = publish.
+// noindex,nofollow is inherited from the shared /apply layout.
+// ---------------------------------------------------------------------------
+
+export function generateMetadata(): Metadata {
+  const resume = getResume();
+  return {
+    title: "Rheza Sulaiman — Head of Engineering (Crypto / Fintech)",
+    description:
+      "Crypto-native engineering leader. Tech Lead @ Arbital. 1st of 116 in a Solana security audit. Ships production systems across Rust, TypeScript, Python.",
+    openGraph: {
+      title: "Rheza Sulaiman — Head of Engineering (Crypto / Fintech)",
+      description: resume.summary.web,
+      type: "profile",
+    },
+  };
+}
+
+// ── Curated hero metrics (presentation-only; not the YAML stats) ────────────
+const METRICS = [
+  { value: "1st", number: 1, sub: "of 116 · Solana security audit" },
+  { value: "13", number: 13, sub: "vulnerabilities reported" },
+  { value: "11", number: 11, sub: "wins · hackathons & bounties" },
+  { value: "$36K+", number: 36, sub: "ecosystem earnings" },
+  { value: "5+", number: 5, sub: "languages shipped to production" },
+  { value: "64+", number: 64, sub: "public repositories" },
+] as const;
+
+// ── Leadership principles ───────────────────────────────────────────────────
+const PRINCIPLES = [
+  {
+    icon: ShieldCheck,
+    title: "Security is a property, not a phase",
+    body: "Ship audited. I placed 1st of 116 reviewing 14 protocols — I bring that lens into every system my teams build.",
+  },
+  {
+    icon: Code2,
+    title: "Polyglot by necessity",
+    body: "Rust, TypeScript, Python, Ruby, SQL — all in production. The right tool wins; a new language (Go next) is a 2–4 week ramp, not a blocker.",
+  },
+  {
+    icon: Zap,
+    title: "Ship under pressure",
+    body: "11 competition wins translate hackathon velocity into production discipline — fast without cutting the edges that matter.",
+  },
+  {
+    icon: BookOpen,
+    title: "Document or it didn't happen",
+    body: "Every architectural choice is traceable. The next engineer — or auditor — can follow the why, not just the what.",
+  },
+] as const;
+
+// ── Skill-category → icon map ───────────────────────────────────────────────
+const SKILL_ICON: Record<string, typeof Code2> = {
+  Languages: Code2,
+  Security: Lock,
+  Frameworks: Sparkles,
+  Databases: Database,
+  Infrastructure: Server,
+  Blockchain: Blocks,
+};
+
+// ── Date helpers ────────────────────────────────────────────────────────────
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+function fmtDate(ym: string): string {
+  const [y, m] = ym.split("-").map(Number);
+  return `${MONTHS[m - 1]} ${y}`;
+}
+function dateRange(a: string, b: string): string {
+  return `${fmtDate(a)} — ${fmtDate(b)}`;
+}
+
+export default function HeadOfEngineeringPage() {
+  const resume = getResume();
+  const { totalEarnings, winCount } = loadAchievements();
+  const { personal, experience, projects, skills, security_expertise, education } = resume;
+
+  const githubUrl = `https://${personal.github}`;
+  const websiteUrl = personal.website.startsWith("http")
+    ? personal.website
+    : `https://${personal.website}`;
+  const avatarSrc = `/images/${personal.avatar}`;
+  const initials = personal.name.split(" ").map((p) => p[0]).join("").slice(0, 2);
+  const buildDate = new Date().toISOString().slice(0, 10);
+
+  return (
+    <div className="hoe-page">
+      {/* ── HERO ─────────────────────────────────────────────────────────── */}
+      <header className="relative overflow-hidden">
+        <div className="hoe-grid-bg pointer-events-none absolute inset-0 hoe-no-print" aria-hidden />
+        <div className="relative mx-auto max-w-5xl px-5 pt-16 pb-12 sm:pt-24">
+          <div className="flex flex-col items-center text-center">
+            <Avatar className="size-24 border-2 border-primary/40 shadow-lg sm:size-28">
+              <AvatarImage src={avatarSrc} alt={personal.name} />
+              <AvatarFallback className="text-2xl font-semibold">{initials}</AvatarFallback>
+            </Avatar>
+
+            <div className="mt-5 flex items-center gap-2 text-xs">
+              <Badge variant="outline" className="border-primary/40 text-primary">
+                Open to Head of Engineering roles
+              </Badge>
+              <Badge variant="secondary" className="gap-1">
+                <MapPin className="size-3" /> Remote · {personal.location.split(",")[0]}
+              </Badge>
+            </div>
+
+            <h1 className="hoe-text-gradient mt-4 text-4xl font-bold tracking-tight sm:text-6xl">
+              {personal.name}
+            </h1>
+            <p className="mt-2 text-sm text-muted-foreground sm:text-base">
+              <span className="font-medium text-foreground">{personal.alias}</span>
+              {" · "}
+              Head of Engineering — Fintech (Crypto)
+            </p>
+
+            <p className="mx-auto mt-5 max-w-2xl text-pretty text-base text-muted-foreground sm:text-lg">
+              Crypto-native engineering leader. I ship production systems across
+              stacks — Rust, TypeScript, Python — and lead teams that do the same.
+              Tech Lead at Arbital, where I built the Agentic Terminal from scratch.
+              1st of 116 in a Solana security audit.
+            </p>
+
+            <div className="mt-7 flex flex-wrap items-center justify-center gap-2">
+              <Button asChild>
+                <a href={githubUrl} target="_blank" rel="noopener noreferrer">
+                  <GitBranch className="size-4" /> GitHub
+                </a>
+              </Button>
+              <Button asChild variant="secondary">
+                <a href={websiteUrl} target="_blank" rel="noopener noreferrer">
+                  <Globe className="size-4" /> rectorspace.com
+                </a>
+              </Button>
+              <Button asChild variant="outline">
+                <a href={`mailto:${personal.email}`}>
+                  <Mail className="size-4" /> {personal.email}
+                </a>
+              </Button>
+              <PrintButton />
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-5xl px-5 pb-24">
+        {/* ── METRICS ──────────────────────────────────────────────────────── */}
+        <ScrollReveal className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6" delay={70}>
+          {METRICS.map((m) => (
+            <div
+              key={m.sub}
+              className="hoe-card-hover rounded-xl border border-border bg-card/60 p-4 text-center"
+            >
+              <div className="text-2xl font-bold text-foreground sm:text-3xl">
+                <Counter number={m.number} display={m.value} />
+              </div>
+              <div className="mt-1 text-[11px] leading-tight text-muted-foreground">{m.sub}</div>
+            </div>
+          ))}
+        </ScrollReveal>
+
+        {/* ── ABOUT ────────────────────────────────────────────────────────── */}
+        <section className="mt-16">
+          <SectionTitle eyebrow="01" title="Profile" />
+          <Card className="hoe-card-hover">
+            <CardContent className="space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
+              <p>
+                I lead engineering for crypto-native products end-to-end —
+                architecture, security, and the team that ships them. As Tech
+                Lead at <strong className="text-foreground">Arbital</strong>, I
+                architected and built the Agentic Terminal from scratch in Rust
+                and TypeScript, after joining as a full-stack developer and
+                earning the promotion to lead the product line.
+              </p>
+              <p>
+                Before that, two years building and auditing Solana Anchor
+                programs independently — including a privacy layer (SIP
+                Protocol) combining NEAR Intents and Zcash shielded transactions,
+                and a government spending-transparency platform on Solana. I
+                also build production AI agents and the MCP tooling they run on.
+              </p>
+              <p className="text-foreground">
+                {education.text}
+              </p>
+            </CardContent>
+          </Card>
+        </section>
+
+        {/* ── SIGNATURE: SECURITY AUDIT WIN ────────────────────────────────── */}
+        <section className="mt-16">
+          <SectionTitle eyebrow="★" title="Signature — Security Audit" />
+          <Card className="hoe-card-hover overflow-hidden border-primary/30">
+            <CardHeader>
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <CardTitle className="flex items-center gap-2 text-lg">
+                  <ShieldCheck className="size-5 text-primary" />
+                  1st of 116 — Solana Security Audit
+                </CardTitle>
+                <Badge className="gap-1">
+                  <Trophy /> Top finisher
+                </Badge>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm leading-relaxed text-muted-foreground sm:text-base">
+              <p>
+                Reviewed <strong className="text-foreground">14 open-source
+                protocols</strong> and reported{" "}
+                <strong className="text-foreground">13 findings</strong>. The top
+                finding was a framework-level Anchor CPI vulnerability
+                (CVSS 7.5) that was fixed upstream — a class of bug affecting
+                every program built on the framework.
+              </p>
+              <p>
+                Security is not a separate phase in my work; it is the lens I use
+                to design systems — PDA validation, signer authority, privilege
+                escalation, reentrancy, and cryptographic correctness from day
+                one.
+              </p>
+            </CardContent>
+          </Card>
+        </section>
+
+        {/* ── EXPERIENCE ───────────────────────────────────────────────────── */}
+        <section className="mt-16">
+          <SectionTitle eyebrow="02" title="Experience" />
+          <div className="space-y-5">
+            {experience.map((exp, i) => {
+              const bullets = webBullets(exp.bullets);
+              const isFeatured = i === 0;
+              return (
+                <Card
+                  key={`${exp.company}-${exp.date_start}`}
+                  className={`hoe-card-hover ${isFeatured ? "border-primary/40" : ""}`}
+                >
+                  <CardHeader>
+                    <div className="flex flex-col gap-1">
+                      <div className="flex flex-wrap items-center justify-between gap-2">
+                        <CardTitle className="text-base sm:text-lg">{exp.title}</CardTitle>
+                        {isFeatured && (
+                          <Badge variant="secondary" className="gap-1">
+                            <Sparkles className="size-3" /> Most recent · Tech Lead
+                          </Badge>
+                        )}
+                      </div>
+                      <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
+                        <span className="font-medium text-foreground">{exp.company}</span>
+                        <span aria-hidden>·</span>
+                        <span>{dateRange(exp.date_start, exp.date_end)}</span>
+                        <span aria-hidden>·</span>
+                        <span>{exp.location}</span>
+                      </div>
+                    </div>
+                  </CardHeader>
+                  <CardContent>
+                    <ul className="space-y-2">
+                      {bullets.map((b) => (
+                        <li key={b.text} className="flex gap-2 text-sm leading-relaxed text-muted-foreground">
+                          <span className="mt-2 size-1.5 shrink-0 rounded-full bg-primary/70" aria-hidden />
+                          <span>{b.text}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+        </section>
+
+        {/* ── FEATURED PROJECTS ────────────────────────────────────────────── */}
+        <section className="mt-16">
+          <SectionTitle eyebrow="03" title="Selected Work" />
+          <ScrollReveal className="grid gap-4 sm:grid-cols-2" delay={80}>
+            {featuredProjects(projects).map((p, i) => {
+              const flagship = i === 0;
+              return (
+                <Card
+                  key={p.name}
+                  className={cn("hoe-card-hover group", flagship && "sm:col-span-2")}
+                >
+                  <CardHeader>
+                    <div className="flex items-start justify-between gap-2">
+                      <CardTitle className="text-base">
+                        {p.name}
+                        {flagship ? (
+                          <Badge variant="secondary" className="ml-2 align-middle text-[10px]">
+                            Flagship
+                          </Badge>
+                        ) : null}
+                      </CardTitle>
+                      <a
+                        href={p.github_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-muted-foreground transition-colors hover:text-primary"
+                        aria-label={`${p.name} on GitHub`}
+                      >
+                        <ArrowUpRight className="size-4" />
+                      </a>
+                    </div>
+                  </CardHeader>
+                  <CardContent>
+                    <div
+                      className={cn(
+                        flagship
+                          ? "flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between"
+                          : "space-y-3",
+                      )}
+                    >
+                      <p className="max-w-xl text-sm leading-relaxed text-muted-foreground">
+                        {p.description}
+                      </p>
+                      <div className="flex flex-wrap gap-1.5">
+                        {p.tags.slice(0, 5).map((t) => (
+                          <Badge
+                            key={t}
+                            variant="outline"
+                            className="font-normal text-muted-foreground"
+                          >
+                            {t}
+                          </Badge>
+                        ))}
+                      </div>
+                    </div>
+                    {p.live_url ? (
+                      <a
+                        href={p.live_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="mt-3 inline-flex items-center gap-1 text-xs text-primary hover:underline"
+                      >
+                        <Globe className="size-3" /> {p.live_url.replace(/^https?:\/\//, "")}
+                      </a>
+                    ) : null}
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </ScrollReveal>
+        </section>
+
+        {/* ── SKILLS (tabs, polyglot-led) ──────────────────────────────────── */}
+        <section className="mt-16">
+          <SectionTitle eyebrow="04" title="Capabilities" />
+          <Tabs defaultValue={skills[0]?.category ?? "Languages"}>
+            <TabsList className="flex w-full flex-wrap justify-start gap-1 h-auto p-1">
+              {skills.map((s) => {
+                const Icon = SKILL_ICON[s.category] ?? Wrench;
+                return (
+                  <TabsTrigger key={s.category} value={s.category} className="gap-1.5">
+                    <Icon className="size-3.5" /> {s.category}
+                  </TabsTrigger>
+                );
+              })}
+            </TabsList>
+
+            {skills.map((s) => (
+              <TabsContent key={s.category} value={s.category} className="mt-4">
+                {s.category === "Languages" && (
+                  <p className="mb-3 text-xs text-muted-foreground">
+                    Polyglot to production. Currently ramping on{" "}
+                    <span className="font-medium text-foreground">Go</span> — the
+                    mental model (concurrency, async runtime) transfers directly
+                    from Rust/Tokio.
+                  </p>
+                )}
+                <div className="flex flex-wrap gap-2">
+                  {s.items.map((item) => (
+                    <Badge key={item} variant="secondary" className="px-2.5 py-1 font-normal">
+                      {item}
+                    </Badge>
+                  ))}
+                </div>
+              </TabsContent>
+            ))}
+          </Tabs>
+
+          {/* Security expertise — visible grid (depth at a glance) */}
+          <div className="mt-8">
+            <h3 className="mb-3 flex items-center gap-2 text-sm font-semibold text-foreground">
+              <Lock className="size-4 text-primary" /> Security expertise
+            </h3>
+            <div className="grid gap-3 sm:grid-cols-2">
+              {security_expertise.map((area, i) => (
+                <div
+                  key={area.area}
+                  className={cn(
+                    "rounded-lg border border-border bg-card/50 p-3",
+                    i === security_expertise.length - 1 && "sm:col-span-2",
+                  )}
+                >
+                  <div className="text-sm font-medium text-foreground">{area.area}</div>
+                  <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{area.detail}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ── HOW I LEAD ───────────────────────────────────────────────────── */}
+        <section className="mt-16">
+          <SectionTitle eyebrow="05" title="How I lead" />
+          <ScrollReveal className="grid gap-4 sm:grid-cols-2" delay={80}>
+            {PRINCIPLES.map((p) => (
+              <Card key={p.title} className="hoe-card-hover">
+                <CardContent className="flex gap-3">
+                  <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                    <p.icon className="size-5" />
+                  </div>
+                  <div>
+                    <div className="text-sm font-semibold text-foreground">{p.title}</div>
+                    <p className="mt-1 text-sm leading-relaxed text-muted-foreground">{p.body}</p>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </ScrollReveal>
+        </section>
+
+        {/* ── FOOTER ──────────────────────────────────────────────────────── */}
+        <footer className="mt-20 border-t border-border pt-8">
+          <div className="flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-center">
+            <div className="text-sm text-muted-foreground">
+              <div className="font-medium text-foreground">{personal.name}</div>
+              <div className="text-xs">
+                {personal.email} · {totalEarnings > 0 || winCount > 0 ? "Open to Head of Engineering (Crypto / Fintech)" : ""}
+              </div>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Button asChild variant="ghost" size="sm">
+                <a href={githubUrl} target="_blank" rel="noopener noreferrer" className="gap-1.5">
+                  <GitBranch className="size-3.5" /> GitHub
+                </a>
+              </Button>
+              <Button asChild variant="ghost" size="sm">
+                <a href={websiteUrl} target="_blank" rel="noopener noreferrer" className="gap-1.5">
+                  <Globe className="size-3.5" /> Website
+                </a>
+              </Button>
+              <Button asChild variant="ghost" size="sm">
+                <a href={`mailto:${personal.email}`} className="gap-1.5">
+                  <Mail className="size-3.5" /> Email
+                </a>
+              </Button>
+            </div>
+          </div>
+          <Separator className="my-5" />
+          <p className="hoe-no-print text-[11px] text-muted-foreground">
+            Built with Next.js 16 · React 19 · shadcn/ui · Tailwind v4 ·{" "}
+            {winCount} wins · ${totalEarnings.toLocaleString("en-US")}+ earned ·
+            updated {buildDate}
+          </p>
+        </footer>
+      </main>
+    </div>
+  );
+}
+
+// ── Small local section-title helper ────────────────────────────────────────
+function SectionTitle({ eyebrow, title }: { eyebrow: string; title: string }) {
+  return (
+    <div className="mb-5 flex items-center gap-3">
+      <span className="font-mono text-xs text-primary">{eyebrow}</span>
+      <h2 className="text-lg font-semibold tracking-tight text-foreground sm:text-xl">{title}</h2>
+      <span className="h-px flex-1 bg-border" aria-hidden />
+    </div>
+  );
+}

--- a/src/components/islands/PrintButton.tsx
+++ b/src/components/islands/PrintButton.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { Printer } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+/**
+ * Triggers the browser print dialog (→ "Save as PDF"). The route's scoped
+ * `hoe.css` has a `@media print` block that strips the dark chrome into a
+ * clean light document, so the printed PDF is recruiter-readable as-is.
+ */
+export function PrintButton() {
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      className="hoe-no-print"
+      onClick={() => window.print()}
+    >
+      <Printer className="size-3.5" />
+      Print / Save PDF
+    </Button>
+  );
+}

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import * as React from "react";
+import * as AccordionPrimitive from "@radix-ui/react-accordion";
+import { ChevronDownIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+function Accordion({
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Root>) {
+  return <AccordionPrimitive.Root data-slot="accordion" {...props} />;
+}
+
+function AccordionItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Item>) {
+  return (
+    <AccordionPrimitive.Item
+      data-slot="accordion-item"
+      className={cn("border-b last:border-b-0", className)}
+      {...props}
+    />
+  );
+}
+
+function AccordionTrigger({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Trigger>) {
+  return (
+    <AccordionPrimitive.Header className="flex">
+      <AccordionPrimitive.Trigger
+        data-slot="accordion-trigger"
+        className={cn(
+          "focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium outline-none transition-all hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <ChevronDownIcon className="text-muted-foreground pointer-events-none size-4 shrink-0 translate-y-0.5 transition-transform duration-200" />
+      </AccordionPrimitive.Trigger>
+    </AccordionPrimitive.Header>
+  );
+}
+
+function AccordionContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Content>) {
+  return (
+    <AccordionPrimitive.Content
+      data-slot="accordion-content"
+      className="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-sm"
+      {...props}
+    >
+      <div className={cn("pt-0 pb-4", className)}>{children}</div>
+    </AccordionPrimitive.Content>
+  );
+}
+
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent };

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import * as React from "react";
+import * as AvatarPrimitive from "@radix-ui/react-avatar";
+
+import { cn } from "@/lib/utils";
+
+function Avatar({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Root>) {
+  return (
+    <AvatarPrimitive.Root
+      data-slot="avatar"
+      className={cn(
+        "relative flex size-10 shrink-0 overflow-hidden rounded-full",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AvatarImage({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Image>) {
+  return (
+    <AvatarPrimitive.Image
+      data-slot="avatar-image"
+      className={cn("aspect-square size-full", className)}
+      {...props}
+    />
+  );
+}
+
+function AvatarFallback({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Fallback>) {
+  return (
+    <AvatarPrimitive.Fallback
+      data-slot="avatar-fallback"
+      className={cn(
+        "bg-muted flex size-full items-center justify-center rounded-full",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Avatar, AvatarImage, AvatarFallback };

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,46 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+        destructive:
+          "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40",
+        outline:
+          "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function Badge({
+  className,
+  variant,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : "span";
+
+  return (
+    <Comp
+      data-slot="badge"
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,56 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40",
+        outline:
+          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2 has-[>svg]:px-3",
+        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
+        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        icon: "size-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+function Button({
+  className,
+  variant,
+  size,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"button"> &
+  VariantProps<typeof buttonVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : "button";
+
+  return (
+    <Comp
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+}
+
+export { Button, buttonVariants };

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,88 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("leading-none font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div data-slot="card-content" className={cn("px-6", className)} {...props} />
+  );
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+};

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import * as React from "react";
+import * as SeparatorPrimitive from "@radix-ui/react-separator";
+
+import { cn } from "@/lib/utils";
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  decorative = true,
+  ...props
+}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+  return (
+    <SeparatorPrimitive.Root
+      data-slot="separator"
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Separator };

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import * as React from "react";
+import * as TabsPrimitive from "@radix-ui/react-tabs";
+
+import { cn } from "@/lib/utils";
+
+function Tabs({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    />
+  );
+}
+
+function TabsList({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      className={cn(
+        "bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TabsTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "data-[state=active]:bg-background data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-1 dark:data-[state=active]:border-input dark:data-[state=active]:text-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TabsContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn("flex-1 outline-none", className)}
+      {...props}
+    />
+  );
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import * as React from "react";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+
+import { cn } from "@/lib/utils";
+
+function TooltipProvider({
+  delayDuration = 0,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delayDuration={delayDuration}
+      {...props}
+    />
+  );
+}
+
+function Tooltip({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return (
+    <TooltipProvider>
+      <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+    </TooltipProvider>
+  );
+}
+
+function TooltipTrigger({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-[--radix-tooltip-content-transform-origin] rounded-md px-3 py-1.5 text-xs text-balance",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <TooltipPrimitive.Arrow className="bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  );
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/src/lib/content/resume.test.ts
+++ b/src/lib/content/resume.test.ts
@@ -61,8 +61,8 @@ describe("loadResume", () => {
         expect(typeof bullet.text).toBe("string");
       }
     }
-    // First entry is the (NDA-anonymized) most-recent role
-    expect(experience[0].company).toBe("Confidential DeFi Startup");
+    // First entry is the most-recent role (Arbital.xyz — NDA lifted, now public)
+    expect(experience[0].company).toBe("Arbital.xyz");
   });
 
   it("projects is a non-empty array with the expected fields", () => {

--- a/src/lib/content/superteam.test.ts
+++ b/src/lib/content/superteam.test.ts
@@ -213,8 +213,8 @@ describe("webBullets", () => {
       expect(shown.length).toBe(exp.bullets.length);
       expect(shown.every((b) => b.web === true)).toBe(true);
     }
-    // Sanity: the first entry (Intric) has all 8 of its bullets on the web.
-    expect(webBullets(experience[0].bullets)).toHaveLength(8);
+    // Sanity: the first entry (Arbital) has all 10 of its bullets on the web.
+    expect(webBullets(experience[0].bullets)).toHaveLength(10);
   });
 
   it("returns an empty array when no bullet is web", () => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,10 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+/**
+ * Merge Tailwind class names with conflict resolution.
+ * Used by shadcn/ui components (Card, Badge, Button, …) on the /apply pages.
+ */
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## What

Targeted, recruiter-facing CV at **/apply/head-of-engineering** for Head of Engineering (Crypto / Fintech) roles. Dark premium theme, noindex, RSC + SSG — same pattern as /apply/superteam.

Built with **shadcn/ui** (vendored, no CLI globals rewrite) on the existing Next 16 / React 19 / Tailwind v4 stack.

## Highlights
- **Scoped theme** (hoe.css): dark palette via `@theme inline` mapped to `--hoe-*` vars defined only under `.hoe-page`. The global cream/brown brand tokens in globals.css are **completely untouched**.
- Sections: hero, animated metrics, profile, **signature security-audit win** (1st/116), experience, selected work (flagship + 2×2), capabilities tabs, security-expertise grid, leadership principles.
- Print stylesheet + PrintButton (Save-as-PDF via window.print()).
- data/resume.yml: de-anonymized **Arbital.xyz** + title → **Tech Lead, Agentic Terminal** (NDA lifted, now public). Tests updated.

## Verification
- npm run build ✅ (route prerenders as static)
- npx tsc --noEmit ✅ · npm run lint ✅ (0 errors) · npm run test ✅ (489/489)
- Copy QA via rendered DOM dump (all text verified correct).

## ⚠️ Review needed before merge → production
1. **Arbital bullets are placeholders** — data/resume.yml has a `⚠️ RECTOR` comment. Need: team size led, what the Agentic Terminal actually does, scale/throughput, exact stack. Don't merge unverified claims to prod.
2. **Avatar** — current rector_profile_image.png may read casual/NFT for a senior Head-of-Eng context. Confirm or swap to headshot/monogram.
3. Once happy → merge → live at rectorspace.com/apply/head-of-engineering → send to recruiter.
